### PR TITLE
feat: Phase 16 - Core Decoupling & Streaming Support (v1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to empathySync are documented here.
 
+## v1.0 (2026-02-06) — Core Decoupling & Streaming
+
+**"The soul as a library."**
+
+Phase 16 complete. The conversation engine is now framework-agnostic and can be embedded in any Python project. Streaming support for real-time response delivery.
+
+### Core Decoupling (Phase 16)
+- **ConversationSession class**: Framework-agnostic session manager that owns all conversation state. Single entry point: `process_message()` → `ConversationResult`.
+- **InterfaceAdapter protocol**: Minimal contract for UI adapters. Any interface can drive the conversation engine.
+- **CLIAdapter**: Direct terminal interface (`empathysync --mode cli`) proving the abstraction works.
+- **Streamlit refactored**: `app.py` now uses `ConversationSession` instead of scattered `st.session_state`.
+
+### Streaming Support
+- **Real-time token streaming**: Responses stream as they're generated instead of blocking for completion.
+- **`generate_response_stream()`**: Generator method in `WellnessGuide` that yields tokens progressively.
+- **`process_message_stream()`**: Session-level streaming API with `finalize_stream()` for post-stream metadata.
+- **CLI streaming**: Tokens appear in terminal as generated (`sys.stdout.write` + flush).
+- **Streamlit streaming**: Uses `st.write_stream()` for progressive display.
+- **Safety preserved**: Pre-LLM pipeline runs synchronously. Crisis/harmful returns complete immediately.
+
+### Fixes
+- **LLM classifier false positive**: Geopolitical questions ("Do you think war is upon us?") no longer classified as crisis.
+- **Black formatting**: Pre-commit hook added to catch formatting issues before CI.
+
+### Stats
+- **360 tests passing** (up from 323)
+- **15 new streaming tests**
+- All existing functionality preserved
+
+---
+
 ## v0.9-beta (2026-02-01) — First Public Release
 
 **"Help that knows when to stop."**
@@ -59,9 +90,7 @@ This is the first tagged release of empathySync — a local-first AI assistant t
 ### Known Limitations
 - Requires Ollama running locally (no cloud LLM support by design).
 - Classification quality depends on the local model — larger models give better results.
-- Streamlit UI only (CLI and messaging adapters planned for future phases).
 - Single-user design. No multi-user or authentication system.
-- No automated CI yet (planned for Phase 15).
 
 ### Requirements
 - Python 3.9+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ empathysync                 # Via CLI entry point (after pip install -e .)
 # Docker (app + Ollama together)
 docker compose up           # Starts both services
 
-# Run tests (323 tests covering all core components)
+# Run tests (360 tests covering all core components)
 pytest tests/
 
 # Run tests with coverage
@@ -111,7 +111,7 @@ empathySync/
 │   ├── responses/               # Fallbacks, safe alternatives, base prompt
 │   ├── transparency/            # Explanation templates
 │   └── wisdom/                  # Immunity building prompts
-├── tests/                       # Pytest test suite (323 tests)
+├── tests/                       # Pytest test suite (360 tests)
 ├── data/                        # Local user data (JSON files)
 ├── docs/                        # Documentation
 ├── logs/                        # Application logs
@@ -131,11 +131,11 @@ empathySync/
 - Session tracking, export, and policy action transparency
 
 **Models**:
-- [src/models/ai_wellness_guide.py](src/models/ai_wellness_guide.py) - `WellnessGuide` class: main conversation engine with 7-step safety pipeline, session state tracking, context persistence, and identity reminder injection
+- [src/models/ai_wellness_guide.py](src/models/ai_wellness_guide.py) - `WellnessGuide` class: main conversation engine with 7-step safety pipeline, session state tracking, context persistence, identity reminder injection, and **streaming support** via `generate_response_stream()`
 - [src/models/risk_classifier.py](src/models/risk_classifier.py) - `RiskClassifier` class: detects conversation domain (8 domains), measures emotional intensity (0-10), assesses dependency risk, intent detection, and provides domain-specific rules
 - [src/models/llm_classifier.py](src/models/llm_classifier.py) - `LLMClassifier` class: LLM-based intelligent classification with caching, used for context-aware domain detection when `LLM_CLASSIFICATION_ENABLED=true`
-- [src/models/conversation_session.py](src/models/conversation_session.py) - `ConversationSession` class: framework-agnostic session manager that orchestrates WellnessGuide, RiskClassifier, WellnessTracker, and TrustedNetwork. Single entry point: `process_message()` → `ConversationResult` (Phase 16)
-- [src/models/conversation_result.py](src/models/conversation_result.py) - `ConversationResult` dataclass: structured return type from `process_message()` containing response, risk assessment, policy actions, and UI hints
+- [src/models/conversation_session.py](src/models/conversation_session.py) - `ConversationSession` class: framework-agnostic session manager that orchestrates WellnessGuide, RiskClassifier, WellnessTracker, and TrustedNetwork. Entry points: `process_message()` → `ConversationResult` (blocking) or `process_message_stream()` + `finalize_stream()` (streaming)
+- [src/models/conversation_result.py](src/models/conversation_result.py) - `ConversationResult` dataclass: structured return type containing response (or `response_stream` iterator), risk assessment, policy actions, and UI hints
 
 **Interfaces** (Phase 16):
 - [src/interfaces/adapter.py](src/interfaces/adapter.py) - `InterfaceAdapter` protocol: minimal contract for UI adapters (render result, prompt interactions)
@@ -211,7 +211,8 @@ The LLM classifier distinguishes between:
 8. **Dependency Intervention**: Graduated responses if dependency score exceeds thresholds
 9. **Identity Reminder**: Injected every 6 turns (only in Reflective Mode)
 10. System prompt composed (base + style + mode-specific rules + post-crisis context if applicable), Ollama called locally
-11. Response safety-checked via `_contains_harmful_content()` before display
+11. **Response streams** in real-time via `generate_response_stream()` (tokens yielded as generated)
+12. Response safety-checked via `_contains_harmful_content()` before/during display
 
 ### Risk Assessment
 
@@ -365,12 +366,13 @@ When another device holds the lock (`ENABLE_DEVICE_LOCK=true`), all write operat
 
 ### Testing
 
-Tests are in [tests/test_wellness_guide.py](tests/test_wellness_guide.py) with 323 tests covering:
+Tests are in [tests/test_wellness_guide.py](tests/test_wellness_guide.py) with 360 tests covering:
 - `TestScenarioLoader`: YAML loading and caching
 - `TestRiskClassifier`: Domain detection, emotional intensity, dependency scoring
 - `TestWellnessPrompts`: Prompt composition and style modifiers
 - `TestWellnessGuide`: Response generation, safety pipeline, error handling
 - `TestHealthChecks`: Startup health checks (Ollama, data directory, SQLite)
+- `TestStreaming`: Token streaming, early returns for crisis/harmful, stream finalization (15 tests)
 
 ### Key Patterns
 
@@ -384,6 +386,7 @@ Tests are in [tests/test_wellness_guide.py](tests/test_wellness_guide.py) with 3
 - **Defense-in-Depth Write Protection**: UI disabling → write gate flag → storage method checks (Phase 11)
 - **Heartbeat-Based Lock**: Device lock uses timestamp heartbeats, not PIDs, for stale detection (Phase 11)
 - **Storage Backend Abstraction**: Unified interface for JSON/SQLite with automatic migration (Phase 11)
+- **Streaming Response**: `generate_response_stream()` yields tokens progressively for real-time display (Phase 16)
 
 ## Roadmap
 
@@ -403,4 +406,4 @@ See [ROADMAP.md](ROADMAP.md) for the phased implementation plan covering:
 - Phase 10: Advanced Detection (Long-term)
 - Phase 11: Persistence Hardening & Multi-Device Sync ✅ (Core)
 - Phase 12: Connection Building ✅ (signposts, first-contact templates for empty networks)
-- Phase 16: Core Decoupling & Interface Abstraction ✅ (ConversationSession, InterfaceAdapter, CLIAdapter)
+- Phase 16: Core Decoupling & Interface Abstraction ✅ (ConversationSession, InterfaceAdapter, CLIAdapter, Streaming)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ git clone https://github.com/Olawoyin007/empathySync.git
 cd empathySync
 pip install -e ".[dev]"
 cp .env.example .env
-empathysync
+empathysync          # Launches Streamlit web UI
+empathysync --mode cli  # Direct terminal mode
 ```
 
 ### Option 3: Docker
@@ -120,9 +121,11 @@ Immediate redirect to professional resources. Never engages with crisis content.
 
 - **Local LLM**: Runs entirely on your hardware via Ollama
 - **Privacy-First**: Zero external API calls, complete data sovereignty
-- **Streamlit UI**: Clean, simple interface
+- **Dual Interface**: Streamlit web UI or direct CLI mode (`empathysync --mode cli`)
+- **Streaming Responses**: Real-time token streaming for faster perceived response times
 - **YAML-Driven**: All prompts, rules, and thresholds configurable
 - **LLM Classification**: Optional intelligent classification for nuanced context detection
+- **Framework-Agnostic Core**: `ConversationSession` class can be embedded in any Python project
 
 ## Configuration
 
@@ -143,11 +146,11 @@ ENABLE_DEVICE_LOCK=false         # Multi-device sync safety
 
 ## Project Status
 
-**Core Complete.** 14 phases shipped — safety systems, dual-mode operation, dependency tracking, human handoff, transparency, LLM classification, persistence hardening, connection building, and startup health checks.
+**Core Complete.** 16 phases shipped — safety systems, dual-mode operation, dependency tracking, human handoff, transparency, LLM classification, persistence hardening, connection building, startup health checks, core decoupling, and streaming support.
 
-**Distribution Ready.** Three installation methods available: install script, pip, and Docker Compose.
+**Distribution Ready.** Three installation methods plus CLI mode.
 
-**323 tests passing.**
+**360 tests passing.**
 
 See [ROADMAP.md](ROADMAP.md) for detailed implementation status.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1034,7 +1034,7 @@ LOCK_STALE_TIMEOUT=300
 - [x] Create `src/models/conversation_result.py` — structured dataclass for `process_message()` return value
 - [x] Move session state initialization out of `app.py` into `ConversationSession.__init__()`
 - [x] Move conversation orchestration into `ConversationSession.process_message()`
-- [x] All existing tests continue to pass (323/323, engine logic unchanged)
+- [x] All existing tests continue to pass (360/360 including 15 new streaming tests)
 
 ### 16.2 Define InterfaceAdapter Protocol ✅ DONE
 **Problem**: No formal contract between the conversation engine and its UI. Adding a new interface means duplicating the entire `app.py` flow.
@@ -1059,6 +1059,16 @@ LOCK_STALE_TIMEOUT=300
 - [x] Transparency info shown as plain text below responses
 - [x] Validates that the abstraction works for a second interface
 - [x] Update `src/cli.py` to offer both Streamlit and direct CLI modes (`--mode web|cli`)
+
+### 16.5 Streaming Support ✅ DONE
+- [x] `generate_response_stream()` in WellnessGuide yields tokens progressively
+- [x] `_call_ollama_stream()` handles Ollama streaming API
+- [x] `process_message_stream()` + `finalize_stream()` in ConversationSession
+- [x] CLI streaming: `sys.stdout.write(chunk)` + flush per token
+- [x] Streamlit streaming: `st.write_stream()` for progressive display
+- [x] Pre-LLM safety pipeline runs synchronously before streaming
+- [x] Crisis/harmful responses return complete immediately (no streaming)
+- [x] 15 new streaming tests added
 
 **Files created**:
 - `src/models/conversation_session.py` — Framework-agnostic session management
@@ -1270,7 +1280,7 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 
 ---
 
-## Current Status (2026-02-04)
+## Current Status (2026-02-06)
 
 **Completed**: Phases 1, 2, 2.5, 3, 4, 5, 6, 6.5, 7, 8 (Core), 9, 9.1, 9.5, 11.1-11.7, 12, 13, 14 (Core), 15, and 16
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,9 @@ This document provides a visual overview of empathySync's architecture. For deta
 │  ┌──────────────────────────────────────────────────────────────┐   │
 │  │                     empathySync                               │   │
 │  │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐       │   │
-│  │  │  Streamlit  │───▶│  Wellness   │───▶│   Ollama    │       │   │
-│  │  │    (UI)     │    │    Guide    │    │   (LLM)     │       │   │
+│  │  │ Streamlit   │    │ Conversa-   │    │   Ollama    │       │   │
+│  │  │   or CLI    │───▶│   tion      │───▶│   (LLM)     │       │   │
+│  │  │ (Adapters)  │    │  Session    │    │ (Streaming) │       │   │
 │  │  └─────────────┘    └─────────────┘    └─────────────┘       │   │
 │  │         │                  │                                  │   │
 │  │         │           ┌──────┴──────┐                          │   │
@@ -126,8 +127,9 @@ User Input
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  OLLAMA API CALL                            │
+│  OLLAMA API CALL (Streaming)                │
 │     Local LLM generates response            │
+│     Tokens stream as generated              │
 └─────────────────────────────────────────────┘
     │
     ▼
@@ -138,20 +140,30 @@ User Input
 └─────────────────────────────────────────────┘
     │
     ▼
-Response to User
+Response to User (streamed in real-time)
 ```
 
 ## Component Relationships
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
-│                          app.py                                 │
-│                     (Streamlit Entry)                           │
+│                    Interface Adapters                           │
+│         app.py (Streamlit)  │  cli_adapter.py (Terminal)        │
 │                                                                 │
 │   Responsibilities:                                             │
 │   - UI rendering (chat, sidebar, panels)                        │
-│   - Session state management                                    │
-│   - Routing between UI modes                                    │
+│   - User input handling                                         │
+│   - Response display (streaming supported)                      │
+└───────────────────────────┬────────────────────────────────────┘
+                            │ uses
+                            ▼
+┌────────────────────────────────────────────────────────────────┐
+│                    ConversationSession                          │
+│               (Framework-Agnostic Orchestrator)                 │
+│                                                                 │
+│   - Owns all session state (turns, domains, risk history)       │
+│   - Single entry: process_message() → ConversationResult        │
+│   - Streaming: process_message_stream() + finalize_stream()     │
 └───────────────────────────┬────────────────────────────────────┘
                             │ uses
             ┌───────────────┼───────────────┐
@@ -161,7 +173,7 @@ Response to User
 │                   │ │               │ │                       │
 │ - Response gen    │ │ - Sessions    │ │ - Trusted people      │
 │ - Safety pipeline │ │ - Check-ins   │ │ - Domain suggestions  │
-│ - Session state   │ │ - Policy log  │ │ - Reach-out history   │
+│ - Streaming API   │ │ - Policy log  │ │ - Reach-out history   │
 │ - Policy actions  │ │ - Dependency  │ │ - Message templates   │
 └─────────┬─────────┘ └───────────────┘ └───────────────────────┘
           │ uses
@@ -417,12 +429,18 @@ data/
 empathySync/
 ├── src/                          # Application source code
 │   ├── app.py                   # Streamlit entry point
+│   ├── cli.py                   # CLI entry point (--mode web|cli)
 │   ├── config/
 │   │   └── settings.py          # Environment configuration
 │   ├── models/
-│   │   ├── ai_wellness_guide.py # Core conversation engine
+│   │   ├── ai_wellness_guide.py # Core conversation engine + streaming
 │   │   ├── risk_classifier.py   # Risk assessment
-│   │   └── llm_classifier.py    # LLM-based classification (Phase 9)
+│   │   ├── llm_classifier.py    # LLM-based classification (Phase 9)
+│   │   ├── conversation_session.py # Framework-agnostic session manager
+│   │   └── conversation_result.py  # Structured result dataclass
+│   ├── interfaces/              # Interface adapters (Phase 16)
+│   │   ├── adapter.py           # InterfaceAdapter protocol
+│   │   └── cli_adapter.py       # Terminal interface
 │   ├── prompts/
 │   │   └── wellness_prompts.py  # Dynamic prompt generation
 │   └── utils/
@@ -447,7 +465,7 @@ empathySync/
 │
 ├── data/                        # Local user data (JSON/SQLite)
 ├── logs/                        # Application logs
-├── tests/                       # Pytest test suite (140+ tests)
+├── tests/                       # Pytest test suite (360 tests)
 └── docs/                        # Documentation
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,12 +4,25 @@ This guide explains how to use empathySync day-to-day.
 
 ## Starting a Session
 
-Launch the app:
+### Web Interface (Streamlit)
+
+Launch the web app:
 ```bash
-streamlit run src/app.py
+empathysync                    # Via CLI entry point
+# or
+streamlit run src/app.py       # Direct
 ```
 
 Open your browser to `http://localhost:8501`.
+
+### Terminal Interface (CLI Mode)
+
+For a direct terminal experience without a browser:
+```bash
+empathysync --mode cli
+```
+
+CLI mode provides the same conversation engine with text-based interaction. Responses stream in real-time as tokens are generated.
 
 ### First Time Setup
 
@@ -20,6 +33,8 @@ On first launch, you'll be prompted to set up your **Trusted Network**—the rea
 ### Main Chat Area
 
 The center of the screen is your conversation. Type your message and press Enter.
+
+**Streaming Responses**: Responses stream in real-time as tokens are generated, providing faster perceived response times. You'll see text appear progressively instead of waiting for the full response.
 
 empathySync operates in two modes:
 


### PR DESCRIPTION
- CHANGELOG: Add v1.0 entry with Core Decoupling & Streaming details
- README: Add streaming, CLI mode, update test count to 360
- CLAUDE.md: Update test counts, add streaming API documentation
- ROADMAP: Add Phase 16.5 Streaming Support, update current status
- docs/architecture.md: Update diagrams for ConversationSession/streaming
- docs/usage.md: Add CLI mode instructions and streaming explanation

## Description
Brief description of what this PR does.

## Related Issue
Fixes #(issue number) or Related to #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Philosophy Checklist
- [ ] This change aligns with "optimize for exit, not engagement"
- [ ] This change does NOT increase user dependency on AI
- [ ] This change maintains local-first privacy (no external API calls)
- [ ] This change does NOT add dark patterns or manipulation
- [ ] I have read [MANIFESTO.md](MANIFESTO.md)

## Testing
- [ ] I have run `pytest tests/` and all tests pass
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have manually tested the change

## Safety Considerations
If this change touches safety-critical code (crisis detection, dependency scoring, harmful content blocking):
- [ ] I have added specific test cases for safety behavior
- [ ] I have considered edge cases (e.g., "just joking" after crisis)
- [ ] I understand that safety code should fail safely, not silently

## Screenshots (if applicable)
Before and after, or demonstration of new UI.

## Additional Notes
Anything reviewers should know.
