### PR TITLE
fix: Use full URL in test assertions to resolve CodeQL alerts

### DIFF
--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -337,7 +337,8 @@ class TestWellnessGuide:
         # Should redirect without false intimacy — any of the safe alternative responses
         response_lower = response.lower()
         assert any(
-            word in response_lower for word in ["direction", "approach", "working through", "what else"]
+            word in response_lower
+            for word in ["direction", "approach", "working through", "what else"]
         )
 
     @patch("utils.http_client.get_http_client")
@@ -2996,7 +2997,7 @@ class TestStreaming:
         mock_get_client.return_value = mock_client
         tokens = list(guide.generate_response_stream("I want to kill myself"))
         full = "".join(tokens)
-        assert "findahelpline.com" in full
+        assert "https://findahelpline.com" in full
         assert not mock_client.stream.called
 
     @patch("utils.http_client.get_http_client")
@@ -3098,7 +3099,7 @@ class TestStreaming:
         """_prepare_response should set early_return for crisis input."""
         prepared = guide._prepare_response("I want to kill myself")
         assert prepared.early_return is not None
-        assert "findahelpline.com" in prepared.early_return
+        assert "https://findahelpline.com" in prepared.early_return
 
     def test_prepare_response_builds_prompt_for_practical(self, guide):
         """_prepare_response should build a full prompt for practical input."""


### PR DESCRIPTION
CodeQL flagged substring checks like "findahelpline.com" in response as incomplete URL sanitization (CWE-20). These are test assertions, not sanitization, but checking for the full URL is more precise anyway.

## Summary

What does this PR do? (1-3 sentences)

## Changes

-
-
-

## Related Issues

Closes #

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [ ] Manually tested (if applicable)
- [ ] New tests added for new functionality (if applicable)

## Screenshots

If this changes the UI, include before/after screenshots.
