### PR TITLE
Docker Compose: auto-pull Ollama model on first run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     container_name: empathysync-ollama
     ports:
       - "11434:11434"
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    environment:
+      - OLLAMA_MODEL=${OLLAMA_MODEL}  
     volumes:
       - ollama_data:/root/.ollama
+      - ./scripts/entrypoint.sh:/entrypoint.sh:ro
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD", "ollama", "list"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+echo "[ollama] Starting Ollama server..."
+ollama serve &
+
+echo "[ollama] Waiting for Ollama to be ready..."
+until ollama list >/dev/null 2>&1; do
+  sleep 2
+done
+
+if [ -z "$OLLAMA_MODEL" ]; then
+  echo "[ollama] ERROR: OLLAMA_MODEL is not set"
+  exit 1
+fi
+
+if ! ollama list | grep -q "$OLLAMA_MODEL"; then
+  echo "[ollama] Pulling model: $OLLAMA_MODEL"
+  ollama pull "$OLLAMA_MODEL"
+else
+  echo "[ollama] Model already present: $OLLAMA_MODEL"
+fi
+
+wait


### PR DESCRIPTION
## Summary

This PR improves the Docker Compose setup by automatically pulling the configured Ollama model on first startup. Users no longer need to manually run ollama pull after bringing the stack up.

## Changes

- Added an entrypoint script for the Ollama container to auto-pull OLLAMA_MODEL if missing
- Replaced the Ollama healthcheck with a native ollama list check to avoid extra dependencies
- Replaced the Ollama healthcheck with a native ollama list check to avoid extra dependencies

## Related Issues

Closes #32

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [*] Manually tested (if applicable)
- [ ] New tests added for new functionality (if applicable)

## Screenshots
NA (No change to UI)
