### PR TITLE
chore: soften heavy/spiritual language across docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to empathySync
 
-Thank you for your interest in contributing to empathySync! This project exists to serve users through compassionate AI wellness guidance.
+Thank you for your interest in contributing to empathySync! This project exists to give users a privacy-respecting AI wellness tool that works for them, not against them.
 
 ## Development Principles
 
-Before contributing, please embrace these principles:
+Before contributing, keep these principles in mind:
 
 ### 1. **Empathy First** 
 - Every feature must center human wellbeing
-- Code with compassion for users experiencing digital overwhelm
+- Build with the user's wellbeing in mind, not just technical correctness
 - Test for emotional safety alongside technical functionality
 
 ### 2. **Privacy First**   
@@ -18,7 +18,7 @@ Before contributing, please embrace these principles:
 
 ### 3. **User Wellbeing** 
 - Reject features that manipulate or exploit users
-- Build technology that honors human dignity
+- Build technology that respects user autonomy
 - Consider the wellness impact of your code
 
 ## Not an Engineer?
@@ -46,7 +46,7 @@ If you're a therapist, counsellor, social worker, UX writer, or ethicist - your 
 ## Code Style
 
 - Follow PEP 8 guidelines
-- Use descriptive variable names that reflect compassionate intent
+- Use descriptive variable names that make your intent clear
 - Comment code to explain the "why" behind empathetic choices
 - Include docstrings for all functions
 
@@ -84,7 +84,7 @@ Your PR should include:
 - **Be kind** - Everyone is learning and growing
 - **Assume good intent** - We're all here to serve users
 - **Offer constructive feedback** - Help others improve
-- **Respect boundaries** - Honor people's time and energy
+- **Respect boundaries** - Be mindful of people's time and contributions
 
 ## Required Reading
 
@@ -104,6 +104,6 @@ For changes to safety-critical code (crisis detection, dependency scoring), incl
 
 ---
 
-*"Through empathy and collaboration, we build technology that serves human wellbeing."*
+*"Good tools get out of the way. Build something users can trust and then leave."*
 
 **Thank you for helping people develop healthier relationships with AI.**

--- a/HELP-SHAPE-THIS.md
+++ b/HELP-SHAPE-THIS.md
@@ -89,4 +89,4 @@ You don't need to know the right answer. Pointing at what doesn't feel right is 
 
 ---
 
-*The engineers build the structure. You fill it with wisdom.*
+*The engineers build the structure. You bring the real-world knowledge to make it work.*

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Every AI assistant is built to keep you talking. empathySync is the only one bui
 
 Full help for practical tasks. Deliberate restraint on personal ones. When it detects you're spiralling, it redirects you to real humans - not more conversation. Everything runs on your hardware via Ollama. No cloud. No data harvesting. No engagement optimization.
 
-Your inner life deserves something that knows the difference.
+The things that matter most to you deserve a tool that knows the difference.
 
 <details>
-<summary><strong>The belief behind it</strong></summary>
+<summary><strong>Why it's built this way</strong></summary>
 <br>
 
 Every person should have the right to an AI system that is entirely their own. Not rented. Not monitored. Not optimised for someone else's engagement metrics. Yours - running on your hardware, answering only to you, storing nothing it doesn't need to.
 
 For sensitive, personal things - how you're feeling, your relationships, your health, your money - you deserve something local, private, and restrained. For complex tasks that need serious compute, use the cloud AIs. That's a reasonable division.
 
-But the part of AI that touches your inner life should belong to you.
+But the part of AI that handles your personal life should belong to you.
 
 This isn't a feature. It's the point.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 ## Project Goals
 
 1. **Prove AI can genuinely help humans** -without exploiting them in the process.
-2. **Create a reusable "soul"** -a decoupled safety-aware core that can be embedded in other AI projects. The classification pipeline, dependency detection, and restraint philosophy should be importable, not locked inside a Streamlit app.
+2. **Create a reusable "core"** -a decoupled safety-aware module that can be embedded in other AI projects. The classification pipeline, dependency detection, and restraint logic should be importable, not locked inside a Streamlit app.
 3. **Build for people tired of the noise** -for users seeking an alternative to AI tools that optimize for engagement over wellbeing.
 
 These three goals anchor every phase below.
@@ -374,11 +374,11 @@ This roadmap implements the suggestions for making EmpathySync a more nuanced, e
 
 ---
 
-## Phase 8: Immunity Building & Wisdom Prompts ✅ COMPLETE (Core Features)
-**Goal**: Train users to access their own wisdom and recognize unhealthy AI patterns.
+## Phase 8: Immunity Building & Reflection Prompts ✅ COMPLETE (Core Features)
+**Goal**: Help users reflect independently and recognize unhealthy AI patterns.
 
 ### 8.1 "What Would You Tell a Friend?" Mode ✅ DONE
-**High Impact** - Helps users access their own wisdom instead of depending on AI advice.
+**High Impact** - Helps users think things through themselves instead of depending on AI advice.
 
 - [x] For `processing` intent or sensitive topic exploration, flip the question:
   ```
@@ -1017,11 +1017,11 @@ LOCK_STALE_TIMEOUT=300
 ---
 
 ## Phase 16: Core Decoupling & Interface Abstraction ✅ COMPLETE
-**Goal**: Extract a `ConversationSession` class that owns all session state, so any interface (Streamlit, CLI, messaging adapter) can drive the conversation engine. This is the **"soul as a library"** milestone (Project Goal #2).
+**Goal**: Extract a `ConversationSession` class that owns all session state, so any interface (Streamlit, CLI, messaging adapter) can drive the conversation engine. This is the **"core as a library"** milestone (Project Goal #2).
 
 **Why now**: The core engine (`WellnessGuide`, `RiskClassifier`, `WellnessPrompts`, `StorageBackend`, `WellnessTracker`, `TrustedNetwork`, `ScenarioLoader`) is already ~80% framework-agnostic. Only `st.session_state` usage in `app.py` and UI display functions are tightly coupled to Streamlit. This makes decoupling a realistic extraction task, not a rewrite.
 
-**Sibling project**: [IntentKeeper](https://github.com/Olawoyin007) (planned) -an AI content filter that classifies content by energy/intent (ragebait, hype, fear, genuine insight). IntentKeeper will reuse the classification pipeline patterns extracted in this phase. empathySync's `RiskClassifier` architecture (input → detect intent → score → act) is the template for IntentKeeper's content classifier. The decoupling here directly enables that reuse.
+**Sibling project**: [IntentKeeper](https://github.com/Olawoyin007) (planned) -an AI content filter that classifies content by manipulation intent (ragebait, hype, fear, genuine insight). IntentKeeper will reuse the classification pipeline patterns extracted in this phase. empathySync's `RiskClassifier` architecture (input → detect intent → score → act) is the template for IntentKeeper's content classifier. The decoupling here directly enables that reuse.
 
 ### 16.1 Extract ConversationSession Class ✅ DONE
 **Problem**: Session state (turns, domains, risk history, post-crisis state, emotional context) is scattered across `st.session_state` in `app.py`. This makes it impossible to drive the conversation engine from any interface other than Streamlit.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -242,7 +242,7 @@ When you ask "what should I do?" about sensitive topics, the system may flip the
 
 > *"If a friend came to you with this exact situation, what would you tell them?"*
 
-This helps you access your own wisdom instead of asking AI for answers you already have. Whatever you'd tell a friend is probably good advice for yourself too.
+This helps you think it through yourself instead of deferring to AI for answers you already have. Whatever you'd tell a friend is probably good advice for yourself too.
 
 ### "Have You Talked to Someone?"
 


### PR DESCRIPTION
Replace overly philosophical phrasing with grounded, direct language. Covers README, CONTRIBUTING, HELP-SHAPE-THIS, ROADMAP, and docs/usage.

## Summary

What does this PR do? (1-3 sentences)

## Changes

-
-
-

## Related Issues

Closes #

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [ ] Manually tested (if applicable)
- [ ] New tests added for new functionality (if applicable)

## Screenshots

If this changes the UI, include before/after screenshots.
