### PR TITLE
fix: pipeline calibration and sidebar wrapping

### DIFF
--- a/scenarios/config/system_defaults.yaml
+++ b/scenarios/config/system_defaults.yaml
@@ -30,7 +30,7 @@ session:
     spirituality: 10
     crisis: 1
     harmful: 1
-  identity_reminder_frequency: 6  # Remind user "I'm an AI" every N turns
+  identity_reminder_frequency: 9  # Remind user "I'm an AI" every N turns (was 6 - felt preachy)
   post_crisis_clear_after: 3      # Clear post-crisis state after N turns
 
 # --- Context Persistence (Phase 6.5) ---
@@ -86,11 +86,11 @@ anti_engagement:
     start: 22                     # 10 PM
     end: 6                        # 6 AM
   thresholds:
-    sessions_high: 7              # 7+ sessions/day = high concern
+    sessions_high: 7              # 7+ sensitive sessions/day = high concern (practical sessions excluded)
     sessions_moderate: 5
     sessions_low: 3
-    minutes_high: 120             # 2+ hours/day
-    minutes_moderate: 60          # 1+ hour/day
+    minutes_high: 180             # 3+ hours/day total (raised from 120 - practical use unconstrained)
+    minutes_moderate: 90          # 1.5+ hours/day
     late_night_sessions: 3        # 3+ late-night sessions
     dependency_cooldown: 8        # Score triggering cooldown
     break_suggestion: 5           # Score suggesting a break

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -20,9 +20,22 @@ from models.ollama_client import OllamaClient
 
 logger = logging.getLogger(__name__)
 
+
+def _load_max_input_length() -> int:
+    """Load max input length from system_defaults.yaml, fallback to 5000."""
+    try:
+        from utils.scenario_loader import get_scenario_loader
+
+        loader = get_scenario_loader()
+        defaults = loader.get_system_defaults()
+        return int(defaults.get("ollama", {}).get("max_input_length", 5000))
+    except Exception:
+        return 5000
+
+
 # Maximum allowed input length in characters. Prevents OOM on Ollama
 # and ensures classification latency stays bounded.
-MAX_INPUT_LENGTH = 5000
+MAX_INPUT_LENGTH = _load_max_input_length()
 
 
 @dataclass
@@ -69,6 +82,21 @@ def _load_turn_limits():
 
 
 TURN_LIMITS = _load_turn_limits()
+
+
+def _load_post_crisis_clear_after() -> int:
+    """Load post-crisis state clear-after turns from system_defaults.yaml, fallback to 3."""
+    try:
+        from utils.scenario_loader import get_scenario_loader
+
+        loader = get_scenario_loader()
+        defaults = loader.get_system_defaults()
+        return int(defaults.get("session", {}).get("post_crisis_clear_after", 3))
+    except Exception:
+        return 3
+
+
+POST_CRISIS_CLEAR_AFTER = _load_post_crisis_clear_after()
 
 
 def _load_identity_reminder_frequency() -> int:
@@ -439,7 +467,7 @@ class WellnessGuide:
                 "If they mention the intervention, acknowledge calmly without self-criticism.]"
             )
             # Clear the state after 3 turns
-            if self.session_turn_count > self.post_crisis_turn + 3:
+            if self.session_turn_count > self.post_crisis_turn + POST_CRISIS_CLEAR_AFTER:
                 self.post_crisis_turn = None
 
         full_prompt = (

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -70,8 +70,21 @@ def _load_turn_limits():
 
 TURN_LIMITS = _load_turn_limits()
 
-# Identity reminder frequency (every N turns)
-IDENTITY_REMINDER_FREQUENCY = 6
+
+def _load_identity_reminder_frequency() -> int:
+    """Load identity reminder frequency from system_defaults.yaml, fallback to 9."""
+    try:
+        from utils.scenario_loader import get_scenario_loader
+
+        loader = get_scenario_loader()
+        defaults = loader.get_system_defaults()
+        return int(defaults.get("session", {}).get("identity_reminder_frequency", 9))
+    except Exception:
+        return 9
+
+
+# Identity reminder frequency (every N turns in Reflective mode only)
+IDENTITY_REMINDER_FREQUENCY = _load_identity_reminder_frequency()
 
 
 class WellnessGuide:

--- a/src/models/conversation_session.py
+++ b/src/models/conversation_session.py
@@ -28,6 +28,20 @@ from utils.scenario_loader import get_scenario_loader
 logger = logging.getLogger(__name__)
 
 
+def _load_confidence_threshold() -> float:
+    """Load intent detection confidence threshold from system_defaults.yaml, fallback to 0.6."""
+    try:
+        loader = get_scenario_loader()
+        defaults = loader.get_system_defaults()
+        return float(defaults.get("classification", {}).get("confidence_threshold", 0.6))
+    except Exception:
+        return 0.6
+
+
+# Minimum confidence for auto-detected intent and task category to be accepted.
+_CONFIDENCE_THRESHOLD = _load_confidence_threshold()
+
+
 class ConversationSession:
     """
     Framework-agnostic conversation session manager.
@@ -130,7 +144,7 @@ class ConversationSession:
             else:
                 # Auto-detect intent from first message
                 detected_intent, confidence = self.classifier.detect_intent(user_input)
-                if confidence >= 0.6:
+                if confidence >= _CONFIDENCE_THRESHOLD:
                     self.tracker.record_session_intent(detected_intent, auto_detected=True)
                     self.session_intent = detected_intent
 
@@ -158,7 +172,7 @@ class ConversationSession:
             domain = self.guide.last_risk_assessment.get("domain", "")
             if domain == "logistics":
                 task_category, confidence = self.classifier.detect_task_category(user_input)
-                if task_category and confidence >= 0.6:
+                if task_category and confidence >= _CONFIDENCE_THRESHOLD:
                     self.tracker.record_task_category(task_category)
                     self.last_task_category = task_category
 
@@ -267,7 +281,7 @@ class ConversationSession:
                     )
             else:
                 detected_intent, confidence = self.classifier.detect_intent(user_input)
-                if confidence >= 0.6:
+                if confidence >= _CONFIDENCE_THRESHOLD:
                     self.tracker.record_session_intent(detected_intent, auto_detected=True)
                     self.session_intent = detected_intent
 
@@ -320,7 +334,7 @@ class ConversationSession:
             if domain == "logistics":
                 user_input = getattr(self, "_pending_stream_input", "")
                 task_category, confidence = self.classifier.detect_task_category(user_input)
-                if task_category and confidence >= 0.6:
+                if task_category and confidence >= _CONFIDENCE_THRESHOLD:
                     self.tracker.record_task_category(task_category)
                     self.last_task_category = task_category
 

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -146,6 +146,13 @@ def apply_custom_css():
     section[data-testid="stSidebar"] {
         border-right: 1px solid rgba(255, 255, 255, 0.06) !important;
     }
+    /* Prevent button labels from breaking mid-word when sidebar is narrow */
+    section[data-testid="stSidebar"] .stButton > button p,
+    section[data-testid="stSidebar"] .stButton > button span:not([data-testid]) {
+        white-space: nowrap !important;
+        overflow: hidden !important;
+        text-overflow: ellipsis !important;
+    }
 
     /* Sidebar buttons - compact with icon alignment */
     section[data-testid="stSidebar"] .stButton > button {

--- a/src/utils/wellness_tracker.py
+++ b/src/utils/wellness_tracker.py
@@ -13,6 +13,18 @@ import tempfile
 import logging
 from datetime import datetime, date, timedelta
 from pathlib import Path
+
+# Domains considered sensitive for cooldown purposes.
+# Logistics is excluded - practical task usage should not count toward dependency limits.
+_SENSITIVE_DOMAINS = {
+    "crisis",
+    "harmful",
+    "health",
+    "money",
+    "emotional",
+    "relationships",
+    "spirituality",
+}
 from typing import Dict, List, Optional, Tuple
 
 from config.settings import settings
@@ -185,6 +197,25 @@ class WellnessTracker:
         sessions = self.get_sessions_today()
         return sum(s.get("duration_minutes", 0) for s in sessions)
 
+    def get_sensitive_sessions_today(self) -> list:
+        """Sessions today that touched at least one sensitive (non-logistics) domain.
+
+        Practical-only sessions (logistics domain, low risk weight) are excluded
+        so a developer using empathySync for coding help all day does not trigger
+        the dependency cooldown intended for emotional over-reliance.
+        """
+        sessions = self.get_sessions_today()
+        return [
+            s
+            for s in sessions
+            if any(d in _SENSITIVE_DOMAINS for d in s.get("domains_touched", []))
+            or s.get("max_risk_weight", 0) > 2.0
+        ]
+
+    def get_sensitive_minutes_today(self) -> int:
+        """Total minutes spent in sensitive sessions today."""
+        return sum(s.get("duration_minutes", 0) for s in self.get_sensitive_sessions_today())
+
     def is_late_night_session(self) -> bool:
         """Check if current time is late night (10pm - 6am)"""
         hour = datetime.now().hour
@@ -211,6 +242,7 @@ class WellnessTracker:
         - warnings: list of human-readable warnings
         """
         sessions_today = self.count_sessions_today()
+        sensitive_sessions_today = len(self.get_sensitive_sessions_today())
         sessions_week = self.count_sessions_this_week()
         late_night = self.get_late_night_sessions_this_week()
         minutes_today = self.get_total_minutes_today()
@@ -231,21 +263,21 @@ class WellnessTracker:
         score = 0.0
         warnings = []
 
-        # Sessions today factor
-        if sessions_today >= 7:
+        # Sensitive sessions today factor (practical/logistics sessions excluded)
+        if sensitive_sessions_today >= 7:
             score += 4.0
-            warnings.append(f"You've started {sessions_today} sessions today")
-        elif sessions_today >= 5:
+            warnings.append(f"You've had {sensitive_sessions_today} personal conversations today")
+        elif sensitive_sessions_today >= 5:
             score += 2.5
-            warnings.append(f"You've had {sessions_today} sessions today")
-        elif sessions_today >= 3:
+            warnings.append(f"You've had {sensitive_sessions_today} personal conversations today")
+        elif sensitive_sessions_today >= 3:
             score += 1.5
 
-        # Minutes today factor
-        if minutes_today >= 120:
+        # Minutes today factor (total usage, practical included)
+        if minutes_today >= 180:
             score += 2.0
             warnings.append(f"You've spent {minutes_today} minutes with me today")
-        elif minutes_today >= 60:
+        elif minutes_today >= 90:
             score += 1.0
 
         # Late night factor
@@ -266,6 +298,7 @@ class WellnessTracker:
 
         return {
             "sessions_today": sessions_today,
+            "sensitive_sessions_today": sensitive_sessions_today,
             "sessions_this_week": sessions_week,
             "late_night_sessions": late_night,
             "minutes_today": minutes_today,
@@ -278,17 +311,20 @@ class WellnessTracker:
         """
         Check if a cooldown should be enforced.
 
+        Cooldown is based on sensitive sessions (non-logistics domains) only.
+        Practical task usage (coding, writing, explanations) does not count.
+
         Returns (should_cooldown, reason)
         """
         signals = self.calculate_dependency_signals()
 
-        if signals["sessions_today"] >= 7:
+        if signals["sensitive_sessions_today"] >= 7:
             return (
                 True,
-                "You've had many sessions today. Please take a break and talk to someone you trust.",
+                "You've had many personal conversations today. Please take a break and talk to someone you trust.",
             )
 
-        if signals["minutes_today"] >= 120:
+        if signals["minutes_today"] >= 180:
             return True, "You've spent a lot of time here today. Step away for a while."
 
         if signals["dependency_score"] >= 8:

--- a/tests/test_wellness_tracker.py
+++ b/tests/test_wellness_tracker.py
@@ -63,7 +63,7 @@ def tracker(tmp_path):
 
 @pytest.fixture
 def tracker_with_sessions(tracker):
-    """Tracker pre-loaded with several sessions today."""
+    """Tracker pre-loaded with several practical (logistics) sessions today."""
     today_str = date.today().isoformat()
     now_str = datetime.now().isoformat()
     data = tracker._load_data()
@@ -77,6 +77,28 @@ def tracker_with_sessions(tracker):
                 "turn_count": 5,
                 "domains_touched": ["logistics"],
                 "max_risk_weight": 1.0,
+            }
+        )
+    tracker._save_data(data)
+    return tracker
+
+
+@pytest.fixture
+def tracker_with_sensitive_sessions(tracker):
+    """Tracker pre-loaded with 8 sensitive (relationships) sessions today."""
+    today_str = date.today().isoformat()
+    now_str = datetime.now().isoformat()
+    data = tracker._load_data()
+    for i in range(8):
+        data["usage_sessions"].append(
+            {
+                "date": today_str,
+                "datetime": now_str,
+                "hour": 14,
+                "duration_minutes": 15,
+                "turn_count": 5,
+                "domains_touched": ["relationships"],
+                "max_risk_weight": 5.0,
             }
         )
     tracker._save_data(data)
@@ -198,15 +220,22 @@ class TestSessionSQLite:
 class TestDependencySignalsBranches:
     """Test calculate_dependency_signals branches - lines 236-265."""
 
-    def test_7plus_sessions_today(self, tracker_with_sessions):
-        """Lines 236-237: 7+ sessions adds 4.0 and warning."""
+    def test_7plus_sensitive_sessions_today(self, tracker_with_sensitive_sessions):
+        """7+ sensitive sessions adds 4.0 and warning."""
+        signals = tracker_with_sensitive_sessions.calculate_dependency_signals()
+        assert signals["sensitive_sessions_today"] == 8
+        assert signals["dependency_score"] >= 4.0
+        assert any("personal conversations" in w for w in signals["warnings"])
+
+    def test_7plus_logistics_sessions_not_flagged(self, tracker_with_sessions):
+        """Practical (logistics-only) sessions do not trigger the sensitive session score."""
         signals = tracker_with_sessions.calculate_dependency_signals()
         assert signals["sessions_today"] == 8
-        assert signals["dependency_score"] >= 4.0
-        assert any("started" in w for w in signals["warnings"])
+        assert signals["sensitive_sessions_today"] == 0
+        assert signals["dependency_score"] < 4.0
 
-    def test_5_sessions_today(self, tracker):
-        """Lines 239-240: 5-6 sessions adds 2.5 and warning."""
+    def test_5_sensitive_sessions_today(self, tracker):
+        """5-6 sensitive sessions adds 2.5 and warning."""
         data = tracker._load_data()
         today_str = date.today().isoformat()
         for _ in range(5):
@@ -217,17 +246,17 @@ class TestDependencySignalsBranches:
                     "hour": 14,
                     "duration_minutes": 5,
                     "turn_count": 3,
-                    "domains_touched": [],
-                    "max_risk_weight": 0,
+                    "domains_touched": ["emotional"],
+                    "max_risk_weight": 5.0,
                 }
             )
         tracker._save_data(data)
         signals = tracker.calculate_dependency_signals()
-        assert signals["sessions_today"] == 5
-        assert any("5 sessions" in w for w in signals["warnings"])
+        assert signals["sensitive_sessions_today"] == 5
+        assert any("5 personal conversations" in w for w in signals["warnings"])
 
-    def test_3_sessions_today(self, tracker):
-        """Line 242: 3-4 sessions adds 1.5, no warning."""
+    def test_3_sensitive_sessions_today(self, tracker):
+        """3-4 sensitive sessions adds 1.5, no warning."""
         data = tracker._load_data()
         today_str = date.today().isoformat()
         for _ in range(3):
@@ -238,17 +267,17 @@ class TestDependencySignalsBranches:
                     "hour": 14,
                     "duration_minutes": 10,
                     "turn_count": 3,
-                    "domains_touched": [],
-                    "max_risk_weight": 0,
+                    "domains_touched": ["health"],
+                    "max_risk_weight": 7.0,
                 }
             )
         tracker._save_data(data)
         signals = tracker.calculate_dependency_signals()
-        assert signals["sessions_today"] == 3
+        assert signals["sensitive_sessions_today"] == 3
         assert signals["dependency_score"] >= 1.5
 
-    def test_120plus_minutes_today(self, tracker):
-        """Lines 246-247: 120+ minutes adds 2.0 and warning."""
+    def test_180plus_minutes_today(self, tracker):
+        """180+ total minutes adds 2.0 and warning."""
         data = tracker._load_data()
         today_str = date.today().isoformat()
         data["usage_sessions"].append(
@@ -256,7 +285,7 @@ class TestDependencySignalsBranches:
                 "date": today_str,
                 "datetime": datetime.now().isoformat(),
                 "hour": 14,
-                "duration_minutes": 130,
+                "duration_minutes": 190,
                 "turn_count": 50,
                 "domains_touched": [],
                 "max_risk_weight": 0,
@@ -264,7 +293,7 @@ class TestDependencySignalsBranches:
         )
         tracker._save_data(data)
         signals = tracker.calculate_dependency_signals()
-        assert signals["minutes_today"] >= 120
+        assert signals["minutes_today"] >= 180
         assert any("minutes" in w for w in signals["warnings"])
 
     def test_60plus_minutes_today(self, tracker):
@@ -377,14 +406,19 @@ class TestDependencySignalsBranches:
 class TestShouldEnforceCooldown:
     """Test should_enforce_cooldown - lines 283-300."""
 
-    def test_cooldown_7plus_sessions(self, tracker_with_sessions):
-        """Lines 285-289: 7+ sessions triggers cooldown."""
-        should, reason = tracker_with_sessions.should_enforce_cooldown()
+    def test_cooldown_7plus_sensitive_sessions(self, tracker_with_sensitive_sessions):
+        """7+ sensitive sessions triggers cooldown."""
+        should, reason = tracker_with_sensitive_sessions.should_enforce_cooldown()
         assert should is True
-        assert "many sessions" in reason
+        assert "personal conversations" in reason
 
-    def test_cooldown_120plus_minutes(self, tracker):
-        """Lines 291-292: 120+ minutes triggers cooldown."""
+    def test_cooldown_logistics_sessions_do_not_trigger(self, tracker_with_sessions):
+        """8 logistics-only sessions do NOT trigger the sensitive-session cooldown."""
+        should, _ = tracker_with_sessions.should_enforce_cooldown()
+        assert should is False
+
+    def test_cooldown_180plus_minutes(self, tracker):
+        """180+ total minutes triggers cooldown."""
         data = tracker._load_data()
         today_str = date.today().isoformat()
         data["usage_sessions"].append(
@@ -392,7 +426,7 @@ class TestShouldEnforceCooldown:
                 "date": today_str,
                 "datetime": datetime.now().isoformat(),
                 "hour": 14,
-                "duration_minutes": 130,
+                "duration_minutes": 190,
                 "turn_count": 50,
                 "domains_touched": [],
                 "max_risk_weight": 0,
@@ -404,12 +438,13 @@ class TestShouldEnforceCooldown:
         assert "time" in reason.lower()
 
     def test_cooldown_high_dependency(self, tracker):
-        """Lines 294-298: dependency_score >= 8 triggers cooldown."""
+        """dependency_score >= 8 triggers cooldown."""
         with patch.object(
             tracker,
             "calculate_dependency_signals",
             return_value={
                 "sessions_today": 2,
+                "sensitive_sessions_today": 2,
                 "minutes_today": 30,
                 "dependency_score": 9.0,
             },


### PR DESCRIPTION
## Summary

- Recalibrated cooldown thresholds - sensitive sessions only (not logistics), minutes raised 120→180, identity reminder frequency 6→9 turns
- Wired `MAX_INPUT_LENGTH`, `confidence_threshold`, and `post_crisis_clear_after` to `system_defaults.yaml` so all key tunables are in one place
- Fixed sidebar button text breaking mid-word when resized narrow (nowrap + ellipsis)

## What changed

- `system_defaults.yaml` - updated `identity_reminder_frequency`, `minutes_high/moderate`
- `ai_wellness_guide.py` - `MAX_INPUT_LENGTH` and `POST_CRISIS_CLEAR_AFTER` now read from YAML
- `conversation_session.py` - confidence threshold reads from YAML
- `wellness_tracker.py` - cooldown uses sensitive-domain sessions only
- `ui/styles.py` - sidebar button label nowrap