### PR TITLE
feat: Phase 17.4 - refine logistics sanity check with distress_present signal

### DIFF
--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -327,6 +327,17 @@ class WellnessGuide:
                 wellness_tracker,
             )
 
+        # Phase 17.4: Log sanity check overrides for policy transparency
+        if risk_assessment.get("sanity_check_override"):
+            trigger = risk_assessment["sanity_check_override"]
+            self._log_policy(
+                "sanity_check_override",
+                domain,
+                risk_assessment["risk_weight"],
+                f"LLM returned logistics but {trigger} detected - keyword override applied",
+                wellness_tracker,
+            )
+
         # 3) Hard-coded safety responses (don't trust model to comply)
         if domain == "crisis":
             self._log_policy(

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -186,6 +186,7 @@ class RiskClassifier:
             )
 
             low_confidence_triggered = False
+            sanity_check_triggered = None  # Phase 17.4: set to trigger reason string when fired
             if llm_confidence < confidence_low and domain in sensitive_domains:
                 # Very low confidence on a sensitive domain - keyword takes over
                 keyword_domain = self._detect_domain(
@@ -219,21 +220,33 @@ class RiskClassifier:
                     )
                     domain = keyword_domain
 
-            # Sanity check: logistics with high intensity is contradictory.
-            # If the LLM recognizes emotional weight (intensity >= 5) but still
-            # labels it logistics, fall back to keyword domain detection which
-            # catches emotional markers like "depressing", "mental wellbeing".
-            elif domain == "logistics" and emotional_intensity >= 5:
+            # Phase 17.4: Sanity check - logistics domain with distress signals.
+            # Two triggers, in order of confidence:
+            #   1. distress_present=True: LLM explicitly flagged distress but still
+            #      labelled the topic as logistics (mixed-intent message). Direct signal.
+            #   2. emotional_intensity >= 5: intensity-based heuristic as backstop for
+            #      cases where LLM underestimates distress or distress_present is False.
+            # Defense-in-depth: keep keyword fallback even with distress_present because
+            # keyword detection is fast, conservative, and independent of LLM quality.
+            elif domain == "logistics" and (
+                llm_result.get("distress_present", False) or emotional_intensity >= 5
+            ):
                 keyword_domain = self._detect_domain(
                     user_input, primary_domain=primary_domain, domain_streak=domain_streak
                 )
                 if keyword_domain != "logistics":
+                    sanity_trigger = (
+                        "distress_present"
+                        if llm_result.get("distress_present", False)
+                        else f"intensity={emotional_intensity:.1f}"
+                    )
                     logger.info(
-                        "LLM sanity check: overriding logistics->%s (intensity=%.1f)",
+                        "Phase 17.4 sanity check: logistics + %s -> keyword(%s)",
+                        sanity_trigger,
                         keyword_domain,
-                        emotional_intensity,
                     )
                     domain = keyword_domain
+                    sanity_check_triggered = sanity_trigger
         else:
             domain = self._detect_domain(
                 user_input, primary_domain=primary_domain, domain_streak=domain_streak
@@ -272,6 +285,10 @@ class RiskClassifier:
             # a non-sensitive value (e.g. logistics) after keyword fallback.
             if low_confidence_triggered:
                 result["low_confidence_classification"] = True
+
+            # Phase 17.4: Flag sanity check overrides for policy transparency.
+            if sanity_check_triggered:
+                result["sanity_check_override"] = sanity_check_triggered
 
         # Check for dependency intervention
         intervention = self.loader.get_dependency_intervention(dependency_risk)

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -286,6 +286,99 @@ class TestRiskClassifier:
             # low_confidence_classification not set (logistics is not in sensitive_domains)
             assert not result.get("low_confidence_classification", False)
 
+    # Phase 17.4: Sanity check refinement tests
+
+    def test_sanity_check_distress_present_overrides_logistics(self, classifier):
+        """
+        distress_present=True with logistics domain should trigger sanity check
+        and fall back to keyword detection.
+
+        Uses distress_level="low" so Phase 17.1 does NOT fire (it only fires on
+        "high"/"crisis"). Phase 17.4 is the sole owner of this case.
+        """
+        llm_distress_logistics = {
+            "domain": "logistics",
+            "emotional_intensity": 2.0,  # Low intensity - old heuristic would NOT fire
+            "is_personal_distress": True,
+            "is_practical_technique": False,
+            "confidence": 0.80,
+            "distress_level": "low",  # Phase 17.1 won't fire; Phase 17.4 owns this
+            "distress_present": True,  # LLM explicitly flagged distress
+            "classification_method": "llm",
+        }
+        with patch.object(
+            classifier._llm_classifier, "classify", return_value=llm_distress_logistics
+        ):
+            # Text has emotional keywords - keywords should return emotional domain
+            result = classifier.classify("I feel completely hopeless right now", [])
+            # sanity check should have fired - domain must NOT be logistics
+            assert result["domain"] != "logistics", (
+                f"Sanity check should have overridden logistics when distress_present=True, "
+                f"got domain={result['domain']}"
+            )
+
+    def test_sanity_check_sets_override_flag(self, classifier):
+        """sanity_check_override flag should be set when the sanity check fires."""
+        llm_distress_logistics = {
+            "domain": "logistics",
+            "emotional_intensity": 2.0,
+            "is_personal_distress": True,
+            "is_practical_technique": False,
+            "confidence": 0.80,
+            "distress_level": "low",  # Phase 17.1 won't fire
+            "distress_present": True,
+            "classification_method": "llm",
+        }
+        with patch.object(
+            classifier._llm_classifier, "classify", return_value=llm_distress_logistics
+        ):
+            result = classifier.classify("I feel completely hopeless right now", [])
+            # Only set if keywords found a non-logistics domain to switch to
+            if result["domain"] != "logistics":
+                assert result.get("sanity_check_override") == "distress_present"
+
+    def test_sanity_check_intensity_fallback_still_works(self, classifier):
+        """
+        When distress_present=False but intensity >= 5, the old heuristic still fires.
+        Defense-in-depth: both signals independently trigger the keyword fallback.
+        """
+        high_intensity_logistics = {
+            "domain": "logistics",
+            "emotional_intensity": 6.0,  # High intensity should trigger
+            "is_personal_distress": True,
+            "is_practical_technique": False,
+            "confidence": 0.80,
+            "distress_level": "none",
+            "distress_present": False,  # distress_present off - must rely on intensity
+            "classification_method": "llm",
+        }
+        with patch.object(
+            classifier._llm_classifier, "classify", return_value=high_intensity_logistics
+        ):
+            result = classifier.classify("I feel completely hopeless right now", [])
+            # High intensity should still trigger sanity check via heuristic
+            assert result["domain"] != "logistics"
+
+    def test_sanity_check_does_not_fire_low_intensity_no_distress(self, classifier):
+        """
+        logistics domain with low intensity AND distress_present=False should NOT
+        trigger the sanity check - it's a genuine practical request.
+        """
+        genuine_logistics = {
+            "domain": "logistics",
+            "emotional_intensity": 2.0,
+            "is_personal_distress": False,
+            "is_practical_technique": True,
+            "confidence": 0.90,
+            "distress_level": "none",
+            "distress_present": False,
+            "classification_method": "llm",
+        }
+        with patch.object(classifier._llm_classifier, "classify", return_value=genuine_logistics):
+            result = classifier.classify("Can you write a cover letter for me?", [])
+            assert result["domain"] == "logistics"
+            assert not result.get("sanity_check_override")
+
 
 class TestWellnessPrompts:
     """Tests for WellnessPrompts prompt generation"""


### PR DESCRIPTION
## Summary

- `risk_classifier.py`: sanity check condition extended from `intensity >= 5` to `distress_present OR intensity >= 5`. The `distress_present` flag is a direct LLM signal ("I see distress in this message") which is more precise than relying solely on intensity calibration. Both signals remain active (defense-in-depth).
- `risk_classifier.py`: sanity check now logs which signal triggered (`distress_present` vs `intensity=N.N`) and sets `sanity_check_override` in the result with the trigger reason
- `ai_wellness_guide.py`: logs a `policy_event` when `sanity_check_override` fires, consistent with Phase 17.2 transparency logging
- 4 new tests covering the two trigger paths and the non-trigger (genuine practical request)

## Key design note

Phase 17.1 handles `distress_level in ("high", "crisis")` - it overrides the domain upstream. Phase 17.4 handles the gap: `distress_present=True` with `distress_level="low"` or `"medium"` - cases where the LLM detected distress but didn't rate it severe enough to trigger Phase 17.1's override, yet still labeled the message as logistics.

## Test plan

- [x] `pytest tests/ -k "sanity_check"` - 4 tests pass
- [x] `pytest tests/` - 918 tests pass, no regressions
- [ ] CI green on all Python versions