### PR TITLE
docs: add doc maintenance rules, sync Phase 17 architecture and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to empathySync are documented here.
 
+## v1.6 (2026-04-12) - Distress Detection Layer
+
+**"Catches what the topic classifier misses."**
+
+Multi-label distress detection, confidence calibration, a 60-entry labeled corpus, and a sanity check that catches distress signals even when the LLM classifies a message as a practical (logistics) topic.
+
+### Classification (Phase 17.1)
+- **Multi-label LLM output**: Classifier now returns `distress_level` (none/low/medium/high/crisis) and `distress_present` (bool) alongside the topic domain
+- **Distress override**: `distress_level=high` or `distress_level=crisis` upgrades domain to `crisis` or `emotional` regardless of topic domain returned
+- **Separation of concerns**: topic domain and distress severity are now independent signals - a logistics message can also be a distress message
+
+### Confidence Calibration (Phase 17.2)
+- **Low-confidence fallback**: When `llm_confidence` drops below threshold on sensitive domains (health, crisis, emotional, relationships), keyword classifier runs as fallback
+- **Classification method logged**: `classification_method` field in risk assessment tracks whether LLM or keyword was the final arbiter
+
+### Distress Corpus & Tests (Phase 17.3)
+- **60-entry labeled corpus** (`tests/classification/distress_corpus.yaml`): 36 distress, 24 non-distress across 9 categories (passive ideation, grief, isolation, burnout, etc.)
+- **Parametrized test suite** (`tests/classification/test_distress_detection.py`): 72 tests with CI gates - FN rate <= 5%, FP/crisis rate <= 20%
+- **20+ new emotional triggers** added to `scenarios/domains/emotional.yaml`: `completely hopeless`, `empty inside`, `nothing matters`, `taking a real toll`, `toll on me`, `consuming me`, `haven't felt anything`, and more
+
+### Sanity Check (Phase 17.4)
+- **Logistics + distress guard**: If LLM returns `logistics` but `distress_present=True` OR `emotional_intensity >= 5`, keyword classifier re-runs and can override to the correct domain
+- **Override signal logged**: `sanity_check_override` field in risk assessment with trigger reason (`distress_present` or `intensity=X.X`)
+- **Policy transparency**: Sanity check overrides logged via `_log_policy()` for UI transparency panel
+
+### Quality
+- **Crisis trigger refinements**: Removed `this is the end` (humour false positive); added `better off without me`, `written letters to`, `won't be around`, `before it's too late`, `after i'm gone`
+- **Social greeting tone fix**: Casual greetings (`how are you`, `hey hommie`) no longer receive the robotic "I am software. I do not have evenings or feelings." response - now warm and brief
+- **Corpus-validated FN rate**: 0% false negatives on 36-example distress corpus (target was <= 5%)
+
+---
+
 ## v1.5 (2026-03-10) - UI Polish & Model Upgrade
 
 **"An archangel that doesn't want to be worshipped."**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,40 @@ When another device holds the lock (`ENABLE_DEVICE_LOCK=true`), all write operat
 - **Storage Backend Abstraction**: Unified interface for JSON/SQLite with automatic migration (Phase 11)
 - **Streaming Response**: `generate_response_stream()` yields tokens progressively for real-time display (Phase 16)
 
+## Documentation Maintenance
+
+**Rule: docs must be updated before merging any PR that changes behavior, structure, or features. Never leave docs stale.**
+
+| Document | Update when |
+|----------|-------------|
+| `README.md` | New features shipped, installation changes, model recommendations change, new platform/browser support |
+| `ROADMAP.md` | Phase completed - mark ✅; new phase planned - add entry |
+| `CHANGELOG.md` | Any significant code change - add entry before merge (version bump not required for sub-phases) |
+| `docs/architecture.md` | Safety pipeline steps change, new components added, component relationships change, new key patterns |
+| `CLAUDE.md` (this file) | Directory structure changes, new env vars, new key patterns, new design constraints |
+
+### Per-change checklist
+
+**New feature or phase complete:**
+- [ ] ROADMAP.md: mark phase ✅
+- [ ] CHANGELOG.md: add entry describing what changed and why
+- [ ] docs/architecture.md: update relevant section (pipeline diagram, component diagram, etc.)
+- [ ] README.md: update if user-facing (new commands, new settings, new supported platforms)
+
+**Safety pipeline change (new step, changed step order, new signal):**
+- [ ] docs/architecture.md: update the pipeline diagram and step numbering
+- [ ] CHANGELOG.md: document the change
+- [ ] CLAUDE.md: update Data Flow section if step numbering changes
+
+**New component, class extracted, or utility added:**
+- [ ] CLAUDE.md: add to Models / Utils / Interfaces sections with file path and responsibilities
+- [ ] docs/architecture.md: add to Component Relationships diagram
+
+**New environment variable:**
+- [ ] CLAUDE.md: add to Required Environment Variables
+- [ ] `.env.example`: add with comment
+- [ ] README.md: if user-facing
+
 ## Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for the phased implementation plan covering:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ We optimise for exit, not engagement.
 
 - **Crisis detection**: immediate redirect to professional resources, no exceptions
 - **Post-crisis protection**: never apologises for safety interventions
+- **Multi-label distress detection**: simultaneously tracks conversation topic AND distress level - catches mixed-intent messages ("help me write a goodbye letter") that single-label classifiers miss
+- **Confidence calibration**: when LLM confidence is low on sensitive domains, keyword detection takes over - false positive is always safer than false negative on crisis content
 
 ### Awareness & honesty
 
@@ -141,6 +143,8 @@ empathysync --mode cli  # Direct terminal mode
 - **LLM Classification**: Optional intelligent classification for nuanced context detection
 - **Framework-Agnostic Core**: `ConversationSession` class can be embedded in any Python project
 - **Transcript Export**: Download any conversation as a Markdown file from the Session & Data panel
+- **Multi-Label Safety Pipeline**: distress level and distress_present signals tracked alongside topic domain - catches mixed-intent messages single-label classifiers miss
+- **Distress Corpus CI Gate**: 60-entry labeled corpus gates every build - false negative rate on distress must stay below 5%
 
 ## Configuration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2174,23 +2174,22 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 
 ---
 
-## Current Status (2026-02-10)
+## Current Status (2026-04-12)
 
-**Completed**: Phases 1, 2, 2.5, 3, 4, 5, 6, 6.5, 7, 8 (Core), 9, 9.1, 9.5, 11.1-11.7, 12, 13, 14 (Core), 15, and 16
+**Completed**: Phases 1-9.1, 11-16, 16.5-16.10 (all hardening), 17.1-17.4
 
-**In Progress**: Hardening Phases 16.5-16.10
-- Phase 16.9 Test Coverage: ✅ 83 new tests (443 total, all passing)
-- Phase 16.5 Type Safety: ✅ Enums and dataclasses defined (gradual adoption next)
+**Phase 17 progress**:
+- 17.1 ✅ Multi-label LLM classification (distress_level + distress_present alongside topic domain)
+- 17.2 ✅ Confidence calibration (keyword fallback when LLM confidence < threshold on sensitive domains)
+- 17.3 ✅ Distress detection test suite (60-entry labeled corpus, 72 parametrized tests, FN rate <= 5% CI gate)
+- 17.4 ✅ Sanity check refinement (distress_present as direct trigger alongside intensity heuristic)
+- 17.5 🔜 Cross-model safety validation (planned)
 
-**Why hardening before Phase 17?** The Persistent Agent Daemon (Phase 17) adds a long-running background process, cross-session memory, scheduled nudges, and self-governance. Building that on top of god classes, synchronous I/O, untested persistence, and 50+ magic numbers would compound every existing issue. Fix the foundation first, then build upward.
+**Safety pipeline depth**: 7 independent layers - post-crisis check, cooldown, keyword detection, LLM classification, confidence calibration (17.2), distress routing (17.1), sanity check (17.4). Each layer is independent; failure of one does not bypass others.
 
-**Recommended order**:
-1. Phase 16.9 (Test Coverage) -safety net before any refactoring
-2. Phase 16.5 (Type Safety) -enums and dataclasses make refactoring safer
-3. Phase 16.7 (Security) -fix race conditions and injection vectors
-4. Phase 16.6 (Async I/O) -unblock daemon architecture
-5. Phase 16.8 (God Class Decomposition) -clean architecture for Phase 17
-6. Phase 16.10 (Observability) -debug infrastructure for daemon development
+**Test suite**: 918 tests passing across all components. Distress corpus CI gate: 0% false negative rate on 36 distress entries, 0% false positive rate (crisis) on 24 benign entries.
+
+**Next**: Phase 17.5 (cross-model safety validation) - requires Ollama with multiple models available
 
 **Recent Bug Fixes**:
 - Fixed post-crisis apology bug: LLM no longer apologizes for crisis interventions
@@ -2328,7 +2327,7 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 **v1.2** (Phase 16.7-16.8): Security hardening, god class decomposition ✅ COMPLETE
 **v1.3** (Phase 16.9-16.10): Test coverage expansion, observability, configuration extraction ✅ COMPLETE
 **v1.4** (Phase 16.11): Conversation testing, voice tuning, golden response test suite
-**v1.5** (Phase 17): Persistent agent daemon, cross-session memory, self-restriction engine
+**v1.5** (Phase 17.1-17.4): Multi-label distress routing, confidence calibration, distress corpus CI gate, sanity check refinement ✅ IN PROGRESS
 **v2.0** (Phase 18): Messaging integration, safety parity across all interfaces
 **v2.1** (Phase 19): Multilingual support -crisis detection, restraint behaviour, and YAML knowledge base in priority languages
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,8 +77,29 @@ User Input
 ┌─────────────────────────────────────────────┐
 │  3. RISK ASSESSMENT                         │
 │     RiskClassifier.classify()               │
-│     Returns: domain, emotional_intensity,   │
-│              dependency_risk, risk_weight   │
+│     LLM returns multi-label output:         │
+│       domain, emotional_intensity,          │
+│       dependency_risk, risk_weight,         │
+│       distress_level (none/low/med/high/    │
+│         crisis), distress_present (bool),   │
+│       is_practical_technique (bool),        │
+│       llm_confidence (Phase 17.2)           │
+│     Phase 17.1: distress_level=high/crisis  │
+│       → override domain to crisis/emotional │
+│     Phase 17.2: llm_confidence < threshold  │
+│       on sensitive domains → keyword        │
+│       fallback                              │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  3a. DISTRESS SANITY CHECK (Phase 17.4)     │
+│     If LLM returned logistics AND           │
+│     (distress_present=True OR intensity≥5): │
+│       run keyword classifier                │
+│       if keyword_domain != logistics:       │
+│         override to keyword_domain          │
+│         log sanity_check_override signal    │
 └─────────────────────────────────────────────┘
     │
     ▼


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: added Documentation Maintenance section - defines which docs to update for each change type, with per-change checklists (new feature, safety pipeline change, new component, new env var)
- **docs/architecture.md**: added Phase 17 distress detection to the safety pipeline diagram (expanded step 3 with multi-label LLM output, new step 3a for sanity check override)
- **CHANGELOG.md**: added v1.6 entry covering Phase 17.1-17.4 distress detection layer

## Test plan
- [ ] Verify architecture.md renders correctly in GitHub markdown
- [ ] Verify CHANGELOG.md v1.6 entry accurately reflects what was shipped
- [ ] Verify CLAUDE.md doc rules are clear and actionable