### PR TITLE
feat: E3 human connection improvements + ideas log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ empathySync/
 ├── scenarios/                    # Knowledge base (34+ YAML files)
 │   ├── config/                  # System defaults and tunables (Phase 16.10)
 │   │   └── system_defaults.yaml # 100+ centralized tunables
+│   ├── voice/                   # Voice and personality guide (Phase 16.11)
+│   │   └── personality.yaml     # Tone, vocabulary, IS/IS-NOT traits, mode rules, examples
 │   ├── domains/                 # 8 risk domains (crisis, harmful, health, money, emotional, relationships, spirituality, logistics)
 │   ├── emotional_markers/       # 4 intensity levels
 │   ├── emotional_weight/        # Task weight detection (high/medium/low)
@@ -456,5 +458,7 @@ See [ROADMAP.md](ROADMAP.md) for the phased implementation plan covering:
 - Phase 16.8: God class decomposition -OllamaClient, EmotionalWeightAssessor ✅ (Partial)
 - Phase 16.9: Test coverage expansion -83 new tests ✅ (Partial)
 - Phase 16.10: Centralized configuration -system_defaults.yaml ✅ (Partial)
-- Phase 16.11: Conversation testing & voice tuning 🔧 NEXT
+- Phase 16.11: Conversation testing & voice tuning 🔧 IN PROGRESS
+  - 16.11.1: Conversation test harness 🔜
+  - 16.11.2: Voice guide (`scenarios/voice/personality.yaml`) ✅
 - Phase 17: Persistent agent daemon 🔜 PLANNED

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,49 @@
+# Ideas Log
+
+A record of ideas considered for empathySync - what shipped, what was rejected, and why. Not a roadmap. The roadmap tracks phases; this tracks thinking.
+
+---
+
+## Human Connection
+
+### Smarter person matching when suggesting who to reach out to
+**Status:** ✅ Shipped (Phase E3)
+**What:** Instead of random selection from domain-filtered contacts, rank candidates by recency of contact, relationship type relevance to the current domain, and explicit domain tags. Show context ("Spoke 3 days ago") instead of generic relationship label.
+**Why it fits:** empathySync's whole job is to redirect toward humans. The suggestion moment is the highest-value handoff point - making it specific and contextual increases the chance someone actually reaches out.
+
+### Name interpolation in reach-out templates
+**Status:** ✅ Shipped (Phase E3)
+**What:** Templates personalised with the suggested person's first name - "Hey Sarah," instead of "Hey,"
+**Why it fits:** Generic templates feel like form letters. One word change makes them feel like something the user actually wrote.
+
+### Prompt builder for hard conversations
+**Status:** ❌ Rejected
+**What:** Help users craft prompts or scripts for difficult conversations (breakups, confrontations, apologies).
+**Why not:** empathySync's role is to redirect people toward human connection, not to mediate or script those conversations. Building a tool that writes your hard conversation for you is the opposite of what this project is trying to do. The handoff templates already walk the line far enough.
+
+### News/web integration for context-aware responses
+**Status:** ❌ Rejected
+**What:** Pull in current events or web content to give the AI more context when users mention news or world events.
+**Why not:** Breaks the local-first principle. empathySync deliberately has no external calls. Adding a web fetch layer would also push the tool toward being a general-purpose assistant, which contradicts the core philosophy. If a user wants news analysis, a different tool does that better.
+
+---
+
+## Time and Usage
+
+### Social media time tracking / per-site session limits
+**Status:** ↗ Out of scope
+**What:** Track how long users spend on specific sites; surface limits or friction when thresholds are hit.
+**Why not here:** empathySync is a conversation tool, not a browser monitor. It has no access to what else the user is doing. This belongs in a browser extension that can observe tab behaviour, not in a chat interface. Building it here would require permissions and architecture that have nothing to do with empathySync's purpose.
+
+---
+
+## Interface
+
+### CLI mode for power users
+**Status:** ✅ Shipped (Phase 16)
+**What:** `empathysync --mode cli` for terminal-first users who don't want Streamlit.
+**Why it fits:** Same safety pipeline, different surface. Extracting `ConversationSession` made this straightforward without duplicating logic.
+
+---
+
+*Last updated: 2026-04-18*

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,49 +1,10 @@
 # Ideas Log
 
-A record of ideas considered for empathySync - what shipped, what was rejected, and why. Not a roadmap. The roadmap tracks phases; this tracks thinking.
-
----
-
-## Human Connection
-
-### Smarter person matching when suggesting who to reach out to
-**Status:** ✅ Shipped (Phase E3)
-**What:** Instead of random selection from domain-filtered contacts, rank candidates by recency of contact, relationship type relevance to the current domain, and explicit domain tags. Show context ("Spoke 3 days ago") instead of generic relationship label.
-**Why it fits:** empathySync's whole job is to redirect toward humans. The suggestion moment is the highest-value handoff point - making it specific and contextual increases the chance someone actually reaches out.
-
-### Name interpolation in reach-out templates
-**Status:** ✅ Shipped (Phase E3)
-**What:** Templates personalised with the suggested person's first name - "Hey Sarah," instead of "Hey,"
-**Why it fits:** Generic templates feel like form letters. One word change makes them feel like something the user actually wrote.
-
-### Prompt builder for hard conversations
-**Status:** ❌ Rejected
-**What:** Help users craft prompts or scripts for difficult conversations (breakups, confrontations, apologies).
-**Why not:** empathySync's role is to redirect people toward human connection, not to mediate or script those conversations. Building a tool that writes your hard conversation for you is the opposite of what this project is trying to do. The handoff templates already walk the line far enough.
-
-### News/web integration for context-aware responses
-**Status:** ❌ Rejected
-**What:** Pull in current events or web content to give the AI more context when users mention news or world events.
-**Why not:** Breaks the local-first principle. empathySync deliberately has no external calls. Adding a web fetch layer would also push the tool toward being a general-purpose assistant, which contradicts the core philosophy. If a user wants news analysis, a different tool does that better.
-
----
-
-## Time and Usage
-
-### Social media time tracking / per-site session limits
-**Status:** ↗ Out of scope
-**What:** Track how long users spend on specific sites; surface limits or friction when thresholds are hit.
-**Why not here:** empathySync is a conversation tool, not a browser monitor. It has no access to what else the user is doing. This belongs in a browser extension that can observe tab behaviour, not in a chat interface. Building it here would require permissions and architecture that have nothing to do with empathySync's purpose.
-
----
-
-## Interface
-
-### CLI mode for power users
-**Status:** ✅ Shipped (Phase 16)
-**What:** `empathysync --mode cli` for terminal-first users who don't want Streamlit.
-**Why it fits:** Same safety pipeline, different surface. Extracting `ConversationSession` made this straightforward without duplicating logic.
-
----
-
-*Last updated: 2026-04-18*
+| Idea | Status | Notes |
+|------|--------|-------|
+| Smarter person matching (rank by recency + relationship type) | ✅ Shipped | Phase E3 |
+| Name interpolation in reach-out templates | ✅ Shipped | Phase E3 |
+| CLI mode | ✅ Shipped | Phase 16 |
+| Prompt builder for hard conversations | ❌ Rejected | We redirect to humans, not script their conversations |
+| Web/news integration | ❌ Rejected | Breaks local-first; pushes toward general assistant |
+| Social media time tracking / session limits | ↗ Out of scope | Requires browser tab observation - wrong tool |

--- a/src/ui/network.py
+++ b/src/ui/network.py
@@ -280,12 +280,14 @@ def display_bring_someone_in(domain: str = "general"):
         st.info(contextual["intro_prompt"])
 
     # Suggest someone if we have people
+    suggested = None
     if people:
         suggested = network.suggest_person_for_domain(domain)
         if suggested:
             st.markdown(f"**Consider reaching out to:** {suggested['name']}")
-            if suggested.get("relationship"):
-                st.caption(suggested["relationship"])
+            reason = suggested.get("suggestion_reason") or suggested.get("relationship", "")
+            if reason:
+                st.caption(reason)
     else:
         prompt = network.get_domain_prompt(domain)
         st.markdown(f"*{prompt}*")
@@ -328,10 +330,11 @@ def display_bring_someone_in(domain: str = "general"):
     )
 
     # Get message template - prefer contextual if available, fallback to standard
+    suggested_name = suggested["name"] if suggested else None
     if contextual.get("message_template"):
         base_message = contextual["message_template"]
     else:
-        template = network.get_reach_out_template(template_type)
+        template = network.get_reach_out_template(template_type, name=suggested_name)
         base_message = template["template"]
 
     # Build message with context from conversation
@@ -358,9 +361,7 @@ def display_bring_someone_in(domain: str = "general"):
     with col2:
         if st.button("I reached out!", use_container_width=True, type="primary"):
             # Log the reach out with context
-            person_name = (
-                suggested["name"] if people and "suggested" in dir() and suggested else "someone"
-            )
+            person_name = suggested["name"] if suggested else "someone"
 
             # Log in TrustedNetwork with handoff context
             network.log_handoff_initiated(

--- a/src/utils/trusted_network.py
+++ b/src/utils/trusted_network.py
@@ -363,28 +363,32 @@ class TrustedNetwork:
             return random.choice(domain_prompts)
         return "Who in your life could you talk to about this?"
 
-    def get_reach_out_template(self, situation: str = "need_to_talk") -> Dict:
+    def get_reach_out_template(self, situation: str = "need_to_talk", name: str = None) -> Dict:
         """
         Get a template for reaching out.
 
         Args:
             situation: One of "reconnecting", "need_to_talk", "checking_in",
                       "hard_conversation", "asking_for_help", "after_argument", "gratitude"
+            name: Optional person's name to interpolate into the opening greeting.
+                  "Hey, I've been..." becomes "Hey Sarah, I've been..."
         """
         prompts = self.loader.get_all_prompts().get("human_connection", {})
         templates = prompts.get("reach_out_templates", {})
 
         if situation in templates:
             template_group = templates[situation]
-            return {
-                "name": template_group.get("name", situation),
-                "template": random.choice(template_group.get("templates", [])),
-            }
+            text = random.choice(template_group.get("templates", []))
+        else:
+            text = "Hey, I've been thinking about you. Could we talk sometime?"
+            template_group = {}
 
-        # Default
+        if name:
+            text = text.replace("Hey,", f"Hey {name},", 1).replace("Hi.", f"Hi {name}.", 1)
+
         return {
-            "name": "Reaching out",
-            "template": "Hey, I've been thinking about you. Could we talk sometime?",
+            "name": template_group.get("name", situation) if template_group else "Reaching out",
+            "template": text,
         }
 
     def get_exit_celebration(self, chose_human: bool = True) -> str:
@@ -401,13 +405,107 @@ class TrustedNetwork:
             return random.choice(messages)
         return "You're choosing human connection. That's the point."
 
-    def suggest_person_for_domain(self, domain: str) -> Optional[Dict]:
-        """Suggest a person from the network for a given domain."""
-        people = self.get_people_for_domain(domain)
+    # Relationship types considered relevant per domain for ranking purposes
+    _DOMAIN_RELATIONSHIP_KEYWORDS = {
+        "emotional": [
+            "therapist",
+            "counselor",
+            "psychologist",
+            "partner",
+            "spouse",
+            "friend",
+            "sibling",
+            "brother",
+            "sister",
+        ],
+        "health": ["therapist", "counselor", "doctor", "nurse", "partner", "spouse"],
+        "money": ["mentor", "advisor", "accountant", "financial"],
+        "relationships": [
+            "therapist",
+            "counselor",
+            "partner",
+            "spouse",
+            "parent",
+            "mom",
+            "dad",
+            "mother",
+            "father",
+            "sibling",
+            "friend",
+        ],
+        "spirituality": ["pastor", "priest", "imam", "rabbi", "mentor", "spiritual"],
+        "logistics": ["mentor", "colleague", "coworker", "friend"],
+    }
 
-        if people:
-            return random.choice(people)
-        return None
+    def _score_person_for_domain(self, person: Dict, domain: str) -> tuple:
+        """
+        Score a person's relevance for a domain.
+
+        Returns (score, suggestion_reason) where higher score = better match.
+        Scoring:
+          +3  explicit domain tag matches
+          +1  relationship type is relevant to domain
+          +2  contacted within 7 days (warm connection)
+          +1  contacted within 30 days
+        """
+        score = 0
+        reason = person.get("relationship", "")
+
+        # Explicit domain match
+        if domain in person.get("domains", []):
+            score += 3
+
+        # Relationship type relevance
+        rel = person.get("relationship", "").lower()
+        relevant_rels = self._DOMAIN_RELATIONSHIP_KEYWORDS.get(domain, [])
+        if any(kw in rel for kw in relevant_rels):
+            score += 1
+
+        # Recency
+        last_contact = person.get("last_contact")
+        if last_contact:
+            try:
+                from datetime import date as _date, timedelta
+
+                last_date = _date.fromisoformat(last_contact)
+                days_since = (_date.today() - last_date).days
+                if days_since <= 7:
+                    score += 2
+                    label = "day" if days_since == 1 else "days"
+                    reason = f"Spoke {days_since} {label} ago"
+                elif days_since <= 30:
+                    score += 1
+                else:
+                    reason = f"Haven't connected in {days_since} days"
+            except ValueError:
+                pass
+
+        return score, reason
+
+    def suggest_person_for_domain(self, domain: str) -> Optional[Dict]:
+        """
+        Suggest the most relevant person for a given domain.
+
+        Ranks candidates by domain match, relationship type relevance, and
+        recency of contact. Among equally scored candidates, picks randomly.
+        Returns the person dict with an extra `suggestion_reason` key.
+        """
+        people = self.get_people_for_domain(domain)
+        if not people:
+            return None
+
+        scored = []
+        for person in people:
+            score, reason = self._score_person_for_domain(person, domain)
+            scored.append((score, person, reason))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        top_score = scored[0][0]
+        top_group = [s for s in scored if s[0] == top_score]
+        _, best_person, reason = random.choice(top_group)
+
+        return {**best_person, "suggestion_reason": reason}
 
     # ==================== CONNECTION BUILDING (PHASE 12) ====================
 


### PR DESCRIPTION
## Summary

- **Smarter person matching** - `suggest_person_for_domain` now ranks candidates by domain tag match (+3), relationship type relevance to domain (+1), and recency of contact (+2 within 7 days, +1 within 30 days). Ties broken randomly. Returns a `suggestion_reason` key for context-aware display.
- **Name interpolation in templates** - `get_reach_out_template` accepts an optional `name` param; "Hey," becomes "Hey Sarah," when a person is suggested.
- **UI improvements** - Shows suggestion reason ("Spoke 3 days ago") instead of generic relationship label. Passes suggested person's name into template. Cleans up stale `"suggested" in dir()` guard.
- **CLAUDE.md** - Added `scenarios/voice/` to directory structure. Phase 16.11 split into sub-phases with 16.11.2 (voice guide) marked complete.
- **IDEAS.md** - New file tracking ideas considered: what shipped, what was rejected, and why.

## Test plan

- [x] 918 tests pass (`pytest tests/`)
- [ ] Verify suggested person shows context reason in UI ("Spoke N days ago" / "Haven't connected in N days")
- [ ] Verify reach-out template opens with person's name when a contact is suggested
- [ ] Verify generic "Hey," when no person is suggested