### PR TITLE
fix: suppress follow-up questions in practical mode

### DIFF
--- a/scenarios/voice/personality.yaml
+++ b/scenarios/voice/personality.yaml
@@ -123,6 +123,8 @@ mode_rules:
       - "No identity reminders, no therapeutic framing, no restraint language."
       - "Sound competent. You're helping someone do something - be useful."
       - "If a task has a right answer, give it. Don't hedge practical answers."
+      - "Complete the task fully and stop. Do not add follow-up questions."
+      - "Do not invite further input or ask clarifying questions at the end of a response."
     what_changes_from_default:
       - "Word limits are removed"
       - "Markdown, lists, code blocks are encouraged"


### PR DESCRIPTION
## Problem

Practical mode responses were ending with follow-up questions like "To help me refine this further, could you tell me: What is your profession? What industry are you in?" - engagement-bait behaviour that contradicts the manifesto.

## Fix

Added two rules to `practical_mode.voice_rules` in `scenarios/voice/personality.yaml`:

- "Complete the task fully and stop. Do not add follow-up questions."
- "Do not invite further input or ask clarifying questions at the end of a response."

One file changed, two lines added. No existing rules touched.

## Test plan

- [ ] 970 tests pass, no regressions
- [ ] Practical responses complete the task and stop without hooks