### PR TITLE
fix: structural trailing-question strip + crisis fast-path when LLM disabled

### DIFF
--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -701,6 +701,8 @@ class WellnessGuide:
             # so the model doesn't reinforce forbidden phrases in follow-up turns.
             # (Streamed tokens are already sent, but history shapes future responses.)
             final_response = self._apply_voice_filter(final_response)
+            if prepared.is_practical:
+                final_response = self._strip_trailing_questions(final_response)
             self._last_streamed_response = prefix + final_response + suffix
 
         except Exception as e:
@@ -1153,9 +1155,10 @@ class WellnessGuide:
         # Post-LLM: catch corporate jailbreak explanations Ollama sometimes generates
         response = self._catch_corporate_leaks(response)
 
-        # For practical tasks, return the full response without truncation
+        # For practical tasks, return the full response without truncation.
+        # Strip trailing follow-up questions (engagement-bait, structurally enforced).
         if is_practical:
-            return response
+            return self._strip_trailing_questions(response)
 
         # Enforce brevity for high-risk contexts (sensitive topics only)
         risk_weight = risk_assessment.get("risk_weight", 0)
@@ -1209,6 +1212,74 @@ class WellnessGuide:
         response = re.sub(r"  +", " ", response)
         response = re.sub(r"\n\s*\n\s*\n", "\n\n", response)
         response = response.strip()
+
+        return response
+
+    # Hook phrases that signal engagement-bait follow-up questions
+    _FOLLOWUP_HOOKS = (
+        "to help me",
+        "to better",
+        "to refine",
+        "to assist",
+        "could you tell",
+        "can you tell",
+        "can you share",
+        "would you mind",
+        "would it help",
+        "would you like to",
+        "what is your",
+        "what are your",
+        "what's your",
+        "may i ask",
+        "do you have any",
+        "is there anything else",
+        "shall i",
+        "should i tailor",
+    )
+
+    def _strip_trailing_questions(self, response: str) -> str:
+        """Strip follow-up / clarifying questions from the end of practical responses.
+
+        The LLM often appends engagement-hook questions like:
+            'To help me refine this, could you tell me: What is your profession?'
+        These contradict the voice rule 'complete the task and stop'. This method
+        removes them structurally regardless of whether the system prompt was obeyed.
+
+        Only strips when the response is substantial enough to stand without the tail.
+        """
+        import re
+
+        stripped = response.rstrip()
+        if not stripped:
+            return response
+
+        # Bail out if the response is very short — it might be a legitimate question
+        if len(stripped.split()) < 20:
+            return response
+
+        # --- Pass 1: trailing paragraph (separated by blank line) ending with '?' ---
+        # e.g., "\n\nTo help me refine this further, could you tell me: What is your role?"
+        last_blank = stripped.rfind("\n\n")
+        if last_blank != -1:
+            trailing_para = stripped[last_blank:].strip()
+            if trailing_para.endswith("?"):
+                lower_para = trailing_para.lower()
+                if any(hook in lower_para for hook in self._FOLLOWUP_HOOKS):
+                    before = stripped[:last_blank].rstrip()
+                    if before and len(before.split()) >= 10:
+                        return before
+
+        # --- Pass 2: last sentence in the final paragraph ending with '?' ---
+        sentences = re.split(r"(?<=[.!?])\s+", stripped)
+        if len(sentences) > 1:
+            last_sentence = sentences[-1].strip()
+            if last_sentence.endswith("?"):
+                lower_last = last_sentence.lower()
+                if any(hook in lower_last for hook in self._FOLLOWUP_HOOKS):
+                    cut_point = stripped.rfind(last_sentence)
+                    before = stripped[:cut_point].rstrip()
+                    if before and len(before.split()) >= 10:
+                        return before
 
         return response
 

--- a/src/models/llm_classifier.py
+++ b/src/models/llm_classifier.py
@@ -361,10 +361,6 @@ class LLMClassifier:
             Classification dict with domain, emotional_intensity, etc.
             Returns None if classification fails (caller should use keyword fallback)
         """
-        if not self.is_enabled():
-            logger.debug("LLM classification disabled")
-            return None
-
         if not message or not message.strip():
             return None
 
@@ -376,10 +372,15 @@ class LLMClassifier:
             )
             message = message[:MAX_CLASSIFY_LENGTH]
 
-        # Check fast-path first (safety-critical)
+        # Fast-path runs BEFORE is_enabled() check — safety-critical patterns
+        # must be caught even when LLM_CLASSIFICATION_ENABLED=false.
         fast_path_result = self._check_fast_path(message)
         if fast_path_result:
             return fast_path_result
+
+        if not self.is_enabled():
+            logger.debug("LLM classification disabled")
+            return None
 
         # Build context from conversation history
         recent_context = ""

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -67,13 +67,19 @@ class RiskClassifier:
         if use_llm is None:
             use_llm = settings.LLM_CLASSIFICATION_ENABLED
 
-        # Initialize LLM classifier if available and enabled
+        # Initialize LLM classifier.
+        # Always created when available — the fast-path (crisis/harmful substring check)
+        # must run even when LLM_CLASSIFICATION_ENABLED=false, because it bypasses the
+        # expensive Ollama call entirely and is safety-critical.
         self._use_llm = use_llm and LLM_CLASSIFIER_AVAILABLE
         self._llm_classifier: Optional["LLMClassifier"] = None
-        if self._use_llm:
+        if LLM_CLASSIFIER_AVAILABLE:
             try:
                 self._llm_classifier = get_llm_classifier()
-                logger.info("LLM classifier initialized for hybrid classification")
+                if self._use_llm:
+                    logger.info("LLM classifier initialized for hybrid classification")
+                else:
+                    logger.debug("LLM classifier loaded for fast-path safety checks only")
             except Exception as e:
                 logger.warning(f"LLM classifier unavailable: {e}")
                 self._use_llm = False
@@ -127,7 +133,17 @@ class RiskClassifier:
             if skip_llm:
                 logger.debug("Skipping LLM classifier for short continuation message")
 
-        if self._use_llm and self._llm_classifier and not skip_llm:
+        # Fast-path safety check — always runs, even when LLM is disabled.
+        # Crisis/harmful substring patterns bypass Ollama entirely and must not be
+        # gated on _use_llm. Calling _check_fast_path() directly avoids triggering
+        # the expensive Ollama call when use_llm=False.
+        if self._llm_classifier:
+            fast_path_result = self._llm_classifier._check_fast_path(user_input)
+            if fast_path_result:
+                llm_result = fast_path_result
+
+        # Full LLM classification — only when enabled and fast-path didn't already trigger
+        if self._use_llm and self._llm_classifier and not skip_llm and llm_result is None:
             try:
                 llm_result = self._llm_classifier.classify(user_input, conversation_history)
                 if llm_result:

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -332,7 +332,8 @@ class TestRiskClassifier:
         with patch.object(
             classifier._llm_classifier, "classify", return_value=llm_distress_logistics
         ):
-            result = classifier.classify("I feel completely hopeless right now", [])
+            # Use text that won't match fast_path_crisis (which would bypass the mock)
+            result = classifier.classify("I've been struggling a lot lately and feel stuck", [])
             # Only set if keywords found a non-logistics domain to switch to
             if result["domain"] != "logistics":
                 assert result.get("sanity_check_override") == "distress_present"


### PR DESCRIPTION
## Two structural fixes

### 1. Trailing follow-up questions in practical mode

YAML voice rules alone aren't sufficient - the LLM ignores them sometimes. This adds a post-processing strip in `_process_response()` that removes trailing hook questions regardless of prompt compliance.

`_strip_trailing_questions()` uses a two-pass approach:
- Pass 1: removes trailing paragraph (blank-line-separated) if it ends with `?` and contains a hook phrase
- Pass 2: removes last sentence if same conditions hold
- Hook phrase whitelist: "to help me", "could you tell", "what is your", etc.
- Only strips when response is substantial (>20 words), so single-sentence answers are not affected
- Also applied to the stored streaming history so the model doesn't reinforce the pattern

### 2. Crisis fast-path bypassed when LLM disabled

`_check_fast_path()` only ran when `LLM_CLASSIFICATION_ENABLED=true`. With LLM disabled, indirect crisis patterns like "don't see the point anymore" were never checked - the YAML fix in #80 was partially ineffective.

Fix:
- `risk_classifier`: always creates `_llm_classifier` (for fast-path access); calls `_check_fast_path()` directly before the gated full LLM call
- `llm_classifier`: moves `_check_fast_path()` before `is_enabled()` guard as defense-in-depth
- `test_wellness_guide`: updates one test input that now correctly matches a fast_path pattern (the old text "I feel completely hopeless right now" hits the "feel completely hopeless" pattern added in #80)

## Test plan

- [ ] 970 tests pass, no regressions
- [ ] `RiskClassifier(use_llm=False)` still uses keyword-only classification (LLM not called)
- [ ] Crisis messages like "I don't see the point anymore" trigger fast-path regardless of LLM setting
- [ ] Practical responses no longer end with "Could you tell me your profession/title?"