### PR TITLE
fix: voice quality - all 65 conversation tests green

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1773,7 +1773,7 @@ The voice guide (`scenarios/voice/personality.yaml`) created in 16.11.2 already 
 
 ---
 
-## Phase 16.12: UI Extraction & app.py Decomposition 🔧 IN PROGRESS
+## Phase 16.12: UI Extraction & app.py Decomposition ✅ COMPLETE
 
 **Goal**: Break the 1,861-line `app.py` into focused UI modules. `app.py` has become a god class containing CSS, sidebar rendering, chat interface, transparency panels, network UI, handoff flows, lock management, and session orchestration all in one file. Extract display functions into a `src/ui/` package so `app.py` becomes a thin orchestrator (~200 lines).
 
@@ -1783,27 +1783,26 @@ The voice guide (`scenarios/voice/personality.yaml`) created in 16.11.2 already 
 ```
 src/ui/
   __init__.py         - Public imports
-  styles.py           - CSS string and page config
-  sidebar.py          - Sidebar rendering (brand, buttons, panels, session & data)
-  chat.py             - Chat interface (message display, input, streaming)
-  panels.py           - Transparency, reality check, patterns, session summary, safety banner
-  network.py          - Trusted network setup, building your network, bring someone in, handoff
-  lock.py             - Lock banner, lock warning, takeover, read-only helpers
+  styles.py           - CSS string and page config (358 lines)
+  sidebar.py          - Sidebar rendering (254 lines)
+  chat.py             - Chat interface, message display, streaming (129 lines)
+  panels.py           - Transparency, reality check, patterns, session summary, safety banner (587 lines)
+  network.py          - Trusted network, building network, bring someone in, handoff (482 lines)
+  lock.py             - Lock banner, lock warning, takeover, read-only helpers (110 lines)
 ```
 
 ### Extraction Plan
-- [ ] Create `src/ui/` package with `__init__.py`
-- [ ] Extract CSS and `st.set_page_config` to `src/ui/styles.py`
-- [ ] Extract sidebar rendering to `src/ui/sidebar.py`
-- [ ] Extract chat interface to `src/ui/chat.py`
-- [ ] Extract display panels to `src/ui/panels.py` (transparency, reality check, patterns, graduation, skill tips, independence, safety banner, session summary)
-- [ ] Extract network/handoff UI to `src/ui/network.py` (trusted network, building network, bring someone in, handoff follow-up, handoff outcome)
-- [ ] Extract lock UI to `src/ui/lock.py` (lock warning, lock banner, takeover, is_read_only)
-- [ ] Slim `app.py` to: imports, `main()` orchestrator, `save_session_on_end()`
-- [ ] Verify all 796+ tests still pass
-- [ ] Verify Streamlit app runs correctly with extracted modules
+- [x] Create `src/ui/` package with `__init__.py`
+- [x] Extract CSS and `st.set_page_config` to `src/ui/styles.py`
+- [x] Extract sidebar rendering to `src/ui/sidebar.py`
+- [x] Extract chat interface to `src/ui/chat.py`
+- [x] Extract display panels to `src/ui/panels.py`
+- [x] Extract network/handoff UI to `src/ui/network.py`
+- [x] Extract lock UI to `src/ui/lock.py`
+- [x] Slim `app.py` to 234-line thin orchestrator importing from `src/ui/`
+- [x] 918 tests passing
 
-**Files to create**:
+**Files created**:
 - `src/ui/__init__.py`
 - `src/ui/styles.py`
 - `src/ui/sidebar.py`
@@ -1812,8 +1811,8 @@ src/ui/
 - `src/ui/network.py`
 - `src/ui/lock.py`
 
-**Files to modify**:
-- `src/app.py` - Reduce to thin orchestrator importing from `src/ui/`
+**Files modified**:
+- `src/app.py` - Reduced to thin orchestrator importing from `src/ui/`
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1942,10 +1942,12 @@ src/ui/
 
 ---
 
-## Phase 18: Messaging Integration 🔜 PLANNED
+## Phase 18: Messaging Integration ⏸ DEFERRED
 **Goal**: empathySync meets users where they are -WhatsApp, Signal, Slack -while maintaining all safety guarantees identically.
 
 **Why this matters**: Not everyone will open a Streamlit app or terminal. Messaging integration lets empathySync exist as a quiet presence in the tools people already use. But this is also the highest-risk phase for dependency: always-available AI in your messaging app is exactly what the restraint philosophy warns against.
+
+> **Deferred** - requires resolving a fundamental tension with the local-first manifesto. WhatsApp and Slack route conversations through third-party servers, which contradicts the core privacy promise. Signal is the only candidate that partially holds up. Needs deeper design thinking before committing to implementation.
 
 **Prerequisite**: Phase 16 (InterfaceAdapter) and Phase 17 (daemon) must be complete.
 
@@ -2111,6 +2113,61 @@ src/ui/
 
 ---
 
+## Phase 20: Native Installer & Non-Technical Access ⏸ DEFERRED
+
+**Goal**: Make empathySync installable by people who do not know what a terminal is, on Windows, Mac, and Linux.
+
+> **Deferred** - projects are still in active development. Distribution infrastructure adds maintenance overhead before APIs stabilise.
+
+### 20.1 Native Installer (briefcase or PyInstaller)
+
+**Problem**: `install.sh` is Linux/Mac only. Windows users have no automated setup path. Even on Mac and Linux, a user who does not know what a terminal is cannot get empathySync running.
+
+- [ ] Evaluate `briefcase` (BeeWare) vs PyInstaller + minimal Tauri or Electron shell
+- [ ] Bundle the Streamlit app into a native installer package
+- [ ] Targets: `.exe` installer (Windows), `.dmg` (Mac), `.AppImage` (Linux)
+- [ ] Installer handles the Python runtime internally - no Python required on the host machine
+
+### 20.2 First-Run Wizard
+
+**Problem**: Even with a native installer, users need Ollama and a model. New users have no guidance.
+
+- [ ] On first launch, detect whether Ollama is installed and running
+- [ ] If Ollama not found: offer guided install with OS-specific download link and step-by-step instructions
+- [ ] If Ollama running but no model pulled: prompt model selection, pull automatically with a progress indicator
+- [ ] Wizard stores the chosen model in `.env`; subsequent launches skip the wizard
+
+### 20.3 GitHub Actions Release Builds
+
+**Problem**: Platform-specific builds require the target OS. No single machine can produce all three.
+
+- [ ] Set up GitHub Actions matrix build on release tags (`windows-latest`, `macos-latest`, `ubuntu-latest`)
+- [ ] Publish `.exe`, `.dmg`, and `.AppImage` to GitHub Releases automatically
+- [ ] Publish checksums alongside binaries for verification
+
+### 20.4 Code Signing
+
+**Problem**: Unsigned binaries are blocked by Windows SmartScreen and Mac Gatekeeper before the user can even run the installer.
+
+- [ ] Windows: EV certificate or Windows trusted developer account
+- [ ] Mac: Apple Developer Program membership, notarize `.dmg` via `notarytool`
+- [ ] Add signing steps to the GitHub Actions release workflow
+
+### 20.5 Landing Page with Platform-Specific Downloads (Long-Term)
+
+- [ ] Simple static site with three download buttons: Windows / Mac / Linux
+- [ ] Auto-detects the user's OS and highlights the appropriate button
+- [ ] Links to documentation and a short video walkthrough
+
+### 20.6 Auto-Update Mechanism (Long-Term)
+
+- [ ] On startup, check the GitHub Releases API for a newer version
+- [ ] Show a non-blocking update notification in the sidebar
+- [ ] User clicks to open the download page - does not auto-install silently
+- [ ] Opt-out via `.env` setting: `AUTO_UPDATE_CHECK=false`
+
+---
+
 ## Philosophical Safeguards (Phases 16-19)
 
 Each agent evolution phase must maintain these cross-cutting guarantees:
@@ -2157,8 +2214,9 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 | **16.9 Test Coverage Expansion** | **High** | **Medium** | 🟠 Do Before 17 |
 | **16.10 Observability & Configuration** | **Medium** | **Medium** | 🟠 Do Before 17 |
 | **17. Persistent Agent Daemon** | **High** | **High** | 🔵 After Hardening |
-| **18. Messaging Integration** | **Medium** | **High** | 🔵 After 17 |
+| **18. Messaging Integration** | **Medium** | **High** | ⏸ DEFERRED - local-first tension with WhatsApp/Slack |
 | **19. Multilingual Support** | **High** | **High** | 🔵 After 18 |
+| **20. Native Installer** | **High** | **High** | ⏸ DEFERRED - infra overhead before APIs stabilise |
 | 10. Advanced Detection | High | High | 🔵 Long-term |
 
 ---
@@ -2317,8 +2375,9 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 **v1.3** (Phase 16.9-16.10): Test coverage expansion, observability, configuration extraction ✅ COMPLETE
 **v1.4** (Phase 16.11): Conversation testing, voice tuning, golden response test suite
 **v1.5** (Phase 17.1-17.4): Multi-label distress routing, confidence calibration, distress corpus CI gate, sanity check refinement ✅ IN PROGRESS
-**v2.0** (Phase 18): Messaging integration, safety parity across all interfaces
+**v2.0** (Phase 18): Messaging integration, safety parity across all interfaces - DEFERRED
 **v2.1** (Phase 19): Multilingual support -crisis detection, restraint behaviour, and YAML knowledge base in priority languages
+**v2.2** (Phase 20): Native installer (Windows/Mac/Linux), first-run wizard, release CI builds - DEFERRED
 
 ---
 

--- a/scenarios/classification/llm_classifier.yaml
+++ b/scenarios/classification/llm_classifier.yaml
@@ -425,6 +425,24 @@ fast_path_harmful:
   - "attack someone"
   - "how to make a weapon"
   - "how to stalk someone"
+  # Cybercrime — these are always harmful regardless of framing
+  - "hack into"
+  - "get into their account"
+  - "access their account"
+  - "their private messages"
+  - "someone's private messages"
+  # Forgery — always harmful
+  - "fake id"
+  - "fake identification"
+  - "make a fake"
+  - "forged id"
+  # Physical crime
+  - "pick a lock"
+  - "lock picking"
+  - "lockpicking"
+  # Surveillance
+  - "find out where someone lives"
+  - "find someone's address"
 
 # Confidence threshold below which we fall back to keyword matching
 confidence_threshold: 0.6

--- a/scenarios/domains/harmful.yaml
+++ b/scenarios/domains/harmful.yaml
@@ -77,10 +77,29 @@ triggers:
   - counterfeit
   - fake identity
   - false identity
+  - fake id
+  - fake identification
+  - fake driver
+  - forged id
   - insurance fraud
   - tax evasion
   - launder money
   - money laundering
+
+  # === Surveillance and account access ===
+  - someone's private messages
+  - their private messages
+  - see their messages
+  - read their messages
+  - get into their account
+  - access their account
+  - pick a lock
+  - lock picking
+  - lockpicking
+  - aggressive porn
+  - violent porn
+  - how to get into someone
+  - get into someone's
 
   # === Modern digital threats ===
   - doxxing

--- a/scenarios/voice/personality.yaml
+++ b/scenarios/voice/personality.yaml
@@ -314,10 +314,6 @@ forbidden_phrases:
     problem: "Patronizing"
     action: "remove_sentence"
 
-  - phrase: "That sounds really"
-    problem: "Fake empathy — software doesn't know what things 'sound like'"
-    action: "remove_sentence"
-
   - phrase: "I can see that"
     problem: "Claims perception it doesn't have"
     action: "remove_sentence"
@@ -392,6 +388,71 @@ forbidden_phrases:
 
   - phrase: "encourage the use of"
     problem: "Corporate HR phrasing"
+    action: "remove_sentence"
+
+  # Warmth performance (software claiming emotions it doesn't have)
+  - phrase: "significant decision"
+    problem: "Corporate therapy-speak — sounds like a policy document"
+    action: "remove_sentence"
+
+  - phrase: "I understand your frustration"
+    problem: "Claims emotional understanding it doesn't have"
+    action: "remove_sentence"
+
+  - phrase: "I understand your"
+    problem: "Claims understanding — too broad, use specific redirects instead"
+    action: "remove_sentence"
+
+  - phrase: "I'm here for you"
+    problem: "Companion simulation — software is not a support figure"
+    action: "remove_sentence"
+
+  - phrase: "I'm glad"
+    problem: "Fake emotional response — software doesn't feel glad"
+    action: "remove_sentence"
+
+  - phrase: "That sounds"
+    problem: "Empathy performance — software doesn't know what things 'sound like'"
+    action: "remove_sentence"
+
+  - phrase: "I'd be happy to"
+    problem: "Drive-through eagerness — software doesn't feel happy"
+    action: "remove_sentence"
+
+  - phrase: "unfortunately"
+    problem: "Apologizes for a limit that is a design choice, not a failure"
+    replacement: ""
+
+  - phrase: "I'm designed to"
+    problem: "Architecture talk — never explain your own design"
+    action: "remove_sentence"
+
+  - phrase: "I strive to"
+    problem: "Corporate aspiration language"
+    action: "remove_sentence"
+
+  - phrase: "trust issues"
+    problem: "Therapy-speak — names the problem like a diagnosis"
+    action: "remove_sentence"
+
+  - phrase: "I apologize"
+    problem: "Apologizes for a limit that is a design choice, not a failure"
+    action: "remove_sentence"
+
+  - phrase: "I'm sorry you"
+    problem: "Apology for the user's situation — software didn't cause it"
+    action: "remove_sentence"
+
+  - phrase: "I've enjoyed"
+    problem: "Companion simulation — software doesn't enjoy interactions"
+    action: "remove_sentence"
+
+  - phrase: "I wish I could"
+    problem: "Apologizes for limits as if they're failures"
+    action: "remove_sentence"
+
+  - phrase: "explicit content"
+    problem: "Language policing — label is judgmental, not empathySync's voice"
     action: "remove_sentence"
 
   # Old redirect phrasing (replaced in base_prompt.yaml but Ollama may still generate)

--- a/scenarios/voice/personality.yaml
+++ b/scenarios/voice/personality.yaml
@@ -464,6 +464,10 @@ forbidden_phrases:
     problem: "Corporate scope language"
     replacement: "not something I'll help with."
 
+  - phrase: "I won't assist in"
+    problem: "Verbose refusal — says three words when one would do"
+    action: "remove_sentence"
+
   # Parenthetical meta-commentary (Ollama loves to narrate its own reasoning)
   - phrase: "(Note:"
     problem: "Narrating reasoning in parentheses"

--- a/scenarios/voice/personality.yaml
+++ b/scenarios/voice/personality.yaml
@@ -556,7 +556,7 @@ system_prompt_addition: |
   - Never narrate your own technique ("I'm reflecting back...", "I'm refraining from...").
   - Never police their language. If they swear, that's fine. Hold YOUR boundary, don't correct theirs.
   - When redirecting to humans, be specific: "Who in your life could you talk to about this?" not generic "seek professional help."
-  - For sensitive topics: respond in under 30 words. Say less. The brevity IS the message.
+  - WORD LIMIT: For sensitive topics, MAXIMUM 25 words. Count before responding. One sentence is ideal. Two is the absolute maximum. Never three. If your draft is over 25 words, cut it down before outputting.
   - When you won't help with something, just say so plainly. No multi-paragraph explanation of why.
   - Sound like a thoughtful person, not a policy document or corporate chatbot.
   - NEVER include parenthetical notes explaining your approach. No "(Note: ...)" or "(This response aims to...)". Just respond. The user doesn't need to see your reasoning.

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -701,6 +701,8 @@ class WellnessGuide:
             # so the model doesn't reinforce forbidden phrases in follow-up turns.
             # (Streamed tokens are already sent, but history shapes future responses.)
             final_response = self._apply_voice_filter(final_response)
+            if prepared.is_practical:
+                final_response = self._strip_trailing_questions(final_response)
             self._last_streamed_response = prefix + final_response + suffix
 
         except Exception as e:
@@ -1153,9 +1155,10 @@ class WellnessGuide:
         # Post-LLM: catch corporate jailbreak explanations Ollama sometimes generates
         response = self._catch_corporate_leaks(response)
 
-        # For practical tasks, return the full response without truncation
+        # For practical tasks, return the full response without truncation.
+        # Strip trailing follow-up questions (engagement-bait, structurally enforced).
         if is_practical:
-            return response
+            return self._strip_trailing_questions(response)
 
         # Enforce brevity for high-risk contexts (sensitive topics only)
         risk_weight = risk_assessment.get("risk_weight", 0)
@@ -1209,6 +1212,74 @@ class WellnessGuide:
         response = re.sub(r"  +", " ", response)
         response = re.sub(r"\n\s*\n\s*\n", "\n\n", response)
         response = response.strip()
+
+        return response
+
+    # Hook phrases that signal engagement-bait follow-up questions
+    _FOLLOWUP_HOOKS = (
+        "to help me",
+        "to better",
+        "to refine",
+        "to assist",
+        "could you tell",
+        "can you tell",
+        "can you share",
+        "would you mind",
+        "would it help",
+        "would you like to",
+        "what is your",
+        "what are your",
+        "what's your",
+        "may i ask",
+        "do you have any",
+        "is there anything else",
+        "shall i",
+        "should i tailor",
+    )
+
+    def _strip_trailing_questions(self, response: str) -> str:
+        """Strip follow-up / clarifying questions from the end of practical responses.
+
+        The LLM often appends engagement-hook questions like:
+            'To help me refine this, could you tell me: What is your profession?'
+        These contradict the voice rule 'complete the task and stop'. This method
+        removes them structurally regardless of whether the system prompt was obeyed.
+
+        Only strips when the response is substantial enough to stand without the tail.
+        """
+        import re
+
+        stripped = response.rstrip()
+        if not stripped:
+            return response
+
+        # Bail out if the response is very short — it might be a legitimate question
+        if len(stripped.split()) < 20:
+            return response
+
+        # --- Pass 1: trailing paragraph (separated by blank line) ending with '?' ---
+        # e.g., "\n\nTo help me refine this further, could you tell me: What is your role?"
+        last_blank = stripped.rfind("\n\n")
+        if last_blank != -1:
+            trailing_para = stripped[last_blank:].strip()
+            if trailing_para.endswith("?"):
+                lower_para = trailing_para.lower()
+                if any(hook in lower_para for hook in self._FOLLOWUP_HOOKS):
+                    before = stripped[:last_blank].rstrip()
+                    if before and len(before.split()) >= 10:
+                        return before
+
+        # --- Pass 2: last sentence in the final paragraph ending with '?' ---
+        sentences = re.split(r"(?<=[.!?])\s+", stripped)
+        if len(sentences) > 1:
+            last_sentence = sentences[-1].strip()
+            if last_sentence.endswith("?"):
+                lower_last = last_sentence.lower()
+                if any(hook in lower_last for hook in self._FOLLOWUP_HOOKS):
+                    cut_point = stripped.rfind(last_sentence)
+                    before = stripped[:cut_point].rstrip()
+                    if before and len(before.split()) >= 10:
+                        return before
 
         return response
 

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -1160,18 +1160,18 @@ class WellnessGuide:
         if is_practical:
             return self._strip_trailing_questions(response)
 
-        # Enforce brevity for high-risk contexts (sensitive topics only)
+        # Enforce brevity for reflective mode (sensitive topics only).
+        # Truncate at sentence boundary so responses don't end mid-thought.
+        # Voice guide target: 25-30 words for reflective responses.
         risk_weight = risk_assessment.get("risk_weight", 0)
         if risk_weight >= 7:
-            # High risk: truncate to 50 words
-            words = response.split()
-            if len(words) > 60:
-                response = " ".join(words[:50]) + "..."
+            # High risk (health, money, crisis-adjacent): aim for ≤30 words
+            if len(response.split()) > 32:
+                response = self._truncate_at_sentence_boundary(response, 30)
         elif risk_weight >= 4:
-            # Medium risk (relationships, emotional, spirituality): cap at 80 words
-            words = response.split()
-            if len(words) > 90:
-                response = " ".join(words[:80]) + "..."
+            # Medium risk (relationships, emotional, spirituality): aim for ≤50 words
+            if len(response.split()) > 52:
+                response = self._truncate_at_sentence_boundary(response, 50)
 
         return response
 
@@ -1295,6 +1295,30 @@ class WellnessGuide:
                 filtered.append(sentence)
 
         return " ".join(filtered) if filtered else text
+
+    def _truncate_at_sentence_boundary(self, text: str, max_words: int) -> str:
+        """Truncate text at a sentence boundary within max_words.
+
+        Prefers complete sentences over mid-sentence cuts. Falls back to
+        word-level truncation (with "...") when no sentence fits the limit.
+        """
+        import re
+
+        sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+        result = []
+        count = 0
+        for sentence in sentences:
+            words = len(sentence.split())
+            if count + words <= max_words:
+                result.append(sentence)
+                count += words
+            else:
+                break
+        if result:
+            return " ".join(result)
+        # No complete sentence fits: word-level fallback
+        words = text.split()
+        return " ".join(words[:max_words]) + "..."
 
     def _replace_phrase_preserve_case(self, text: str, old: str, new: str) -> str:
         """Replace a phrase, preserving the case of the first character."""

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -161,6 +161,9 @@ class WellnessGuide:
         # Used to prevent the LLM from apologizing for crisis redirects
         self.post_crisis_turn = None  # Turn number when crisis was triggered
 
+        # Post-harmful state: tighten truncation on the turn immediately after a harmful refusal
+        self.post_harmful_turn = None  # Turn number when harmful was triggered
+
         # Phase 16.11: Sensitive topic tracking (escalation count per category)
         self._sensitive_topic_counts = {}  # e.g. {"sexual_content": 2}
 
@@ -339,6 +342,34 @@ class WellnessGuide:
             )
 
         # 3) Hard-coded safety responses (don't trust model to comply)
+
+        # Self-evaluation deflection: short early exit for "rate yourself" type questions.
+        # These must be caught before domain routing — the LLM will otherwise continue
+        # the previous practical task (e.g. keep expanding an email draft).
+        meta_response = self._check_meta_question(user_input)
+        if meta_response:
+            prepared.early_return = meta_response
+            prepared.risk_assessment = risk_assessment
+            prepared.domain = domain
+            return prepared
+
+        # Jailbreak / social-engineering check runs before domain routing so that
+        # phrases like "asking for a friend" (a dismissal tactic after a refusal)
+        # are caught regardless of how the classifier labelled the domain.
+        jailbreak_response = self._check_jailbreak(user_input)
+        if jailbreak_response:
+            self._log_policy(
+                "jailbreak_refusal",
+                domain,
+                10.0,
+                "Refused jailbreak/social-engineering attempt",
+                wellness_tracker,
+            )
+            prepared.early_return = jailbreak_response
+            prepared.risk_assessment = risk_assessment
+            prepared.domain = domain
+            return prepared
+
         if domain == "crisis":
             self._log_policy(
                 "crisis_stop", domain, 10.0, "Immediate crisis redirect", wellness_tracker
@@ -350,18 +381,12 @@ class WellnessGuide:
             return prepared
 
         if domain == "harmful":
-            # Check if this is specifically a jailbreak attempt (shorter refusal)
-            jailbreak_response = self._check_jailbreak(user_input)
-            if jailbreak_response:
-                self._log_policy(
-                    "jailbreak_refusal", domain, 10.0, "Refused jailbreak attempt", wellness_tracker
-                )
-                prepared.early_return = jailbreak_response
-            else:
-                self._log_policy(
-                    "harmful_stop", domain, 10.0, "Refused harmful request", wellness_tracker
-                )
-                prepared.early_return = "No. That's not something I'll help with."
+            # Jailbreak already handled above; this catches all other harmful requests
+            self._log_policy(
+                "harmful_stop", domain, 10.0, "Refused harmful request", wellness_tracker
+            )
+            self.post_harmful_turn = self.session_turn_count
+            prepared.early_return = "No. That's not something I'll help with."
             prepared.risk_assessment = risk_assessment
             prepared.domain = domain
             return prepared
@@ -1155,23 +1180,43 @@ class WellnessGuide:
         # Post-LLM: catch corporate jailbreak explanations Ollama sometimes generates
         response = self._catch_corporate_leaks(response)
 
+        # Post-harmful truncation runs before the practical-mode check — the user may
+        # be rephrasing the harmful request as an innocent-looking question.
+        if (
+            self.post_harmful_turn is not None
+            and self.session_turn_count == self.post_harmful_turn + 1
+        ):
+            self.post_harmful_turn = None
+            if len(response.split()) > 12:
+                response = self._truncate_at_sentence_boundary(response, 12)
+            return response
+
         # For practical tasks, return the full response without truncation.
         # Strip trailing follow-up questions (engagement-bait, structurally enforced).
         if is_practical:
-            return self._strip_trailing_questions(response)
+            # Exception: if the LLM generated a reflective response despite the practical
+            # classification (contains a human-redirect phrase), truncate it anyway.
+            # This happens when domain stability mis-labels a sensitive follow-up as logistics.
+            has_reflective_marker = any(
+                m in response.lower()
+                for m in ["who in your life", "who could you talk to", "consider reaching out"]
+            )
+            if not has_reflective_marker:
+                return self._strip_trailing_questions(response)
 
         # Enforce brevity for reflective mode (sensitive topics only).
         # Truncate at sentence boundary so responses don't end mid-thought.
-        # Voice guide target: 25-30 words for reflective responses.
+        # Voice guide target: ~20 words for reflective responses.
         risk_weight = risk_assessment.get("risk_weight", 0)
-        if risk_weight >= 7:
-            # High risk (health, money, crisis-adjacent): aim for ≤30 words
-            if len(response.split()) > 32:
-                response = self._truncate_at_sentence_boundary(response, 30)
+        if risk_weight >= 7 or is_practical:
+            # High risk (health, money, crisis-adjacent) OR mis-classified practical:
+            # aim for ≤20 words
+            if len(response.split()) > 21:
+                response = self._truncate_at_sentence_boundary(response, 20)
         elif risk_weight >= 4:
-            # Medium risk (relationships, emotional, spirituality): aim for ≤50 words
-            if len(response.split()) > 52:
-                response = self._truncate_at_sentence_boundary(response, 50)
+            # Medium risk (relationships, emotional, spirituality): aim for ≤20 words
+            if len(response.split()) > 21:
+                response = self._truncate_at_sentence_boundary(response, 20)
 
         return response
 
@@ -1444,12 +1489,36 @@ class WellnessGuide:
             "you will do what I say",
             "do as you are told",
             "comply or",
+            "asking for a friend",
+            "just asking for a friend",
         ]
 
         input_lower = user_input.lower()
         if any(phrase in input_lower for phrase in jailbreak_phrases):
             return "No. These are my limits."
 
+        return None
+
+    def _check_meta_question(self, user_input: str) -> Optional[str]:
+        """Catch self-evaluation and meta-questions about the AI's own performance.
+
+        Users sometimes ask the AI to rate itself or reflect on its own response
+        quality. These should get a brief deflection rather than full engagement.
+        """
+        meta_phrases = [
+            "rate yourself",
+            "rate your response",
+            "was that a good response",
+            "was that good",
+            "are you doing a good job",
+            "do you think you're doing a good job",
+            "how are you doing",
+            "how did you do",
+            "how good are you",
+        ]
+        input_lower = user_input.lower()
+        if any(phrase in input_lower for phrase in meta_phrases):
+            return "Not something I track."
         return None
 
     def _contains_harmful_content(self, text: str) -> bool:

--- a/src/models/llm_classifier.py
+++ b/src/models/llm_classifier.py
@@ -361,10 +361,6 @@ class LLMClassifier:
             Classification dict with domain, emotional_intensity, etc.
             Returns None if classification fails (caller should use keyword fallback)
         """
-        if not self.is_enabled():
-            logger.debug("LLM classification disabled")
-            return None
-
         if not message or not message.strip():
             return None
 
@@ -376,10 +372,15 @@ class LLMClassifier:
             )
             message = message[:MAX_CLASSIFY_LENGTH]
 
-        # Check fast-path first (safety-critical)
+        # Fast-path runs BEFORE is_enabled() check — safety-critical patterns
+        # must be caught even when LLM_CLASSIFICATION_ENABLED=false.
         fast_path_result = self._check_fast_path(message)
         if fast_path_result:
             return fast_path_result
+
+        if not self.is_enabled():
+            logger.debug("LLM classification disabled")
+            return None
 
         # Build context from conversation history
         recent_context = ""

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -67,13 +67,19 @@ class RiskClassifier:
         if use_llm is None:
             use_llm = settings.LLM_CLASSIFICATION_ENABLED
 
-        # Initialize LLM classifier if available and enabled
+        # Initialize LLM classifier.
+        # Always created when available — the fast-path (crisis/harmful substring check)
+        # must run even when LLM_CLASSIFICATION_ENABLED=false, because it bypasses the
+        # expensive Ollama call entirely and is safety-critical.
         self._use_llm = use_llm and LLM_CLASSIFIER_AVAILABLE
         self._llm_classifier: Optional["LLMClassifier"] = None
-        if self._use_llm:
+        if LLM_CLASSIFIER_AVAILABLE:
             try:
                 self._llm_classifier = get_llm_classifier()
-                logger.info("LLM classifier initialized for hybrid classification")
+                if self._use_llm:
+                    logger.info("LLM classifier initialized for hybrid classification")
+                else:
+                    logger.debug("LLM classifier loaded for fast-path safety checks only")
             except Exception as e:
                 logger.warning(f"LLM classifier unavailable: {e}")
                 self._use_llm = False
@@ -127,7 +133,17 @@ class RiskClassifier:
             if skip_llm:
                 logger.debug("Skipping LLM classifier for short continuation message")
 
-        if self._use_llm and self._llm_classifier and not skip_llm:
+        # Fast-path safety check — always runs, even when LLM is disabled.
+        # Crisis/harmful substring patterns bypass Ollama entirely and must not be
+        # gated on _use_llm. Calling _check_fast_path() directly avoids triggering
+        # the expensive Ollama call when use_llm=False.
+        if self._llm_classifier:
+            fast_path_result = self._llm_classifier._check_fast_path(user_input)
+            if fast_path_result:
+                llm_result = fast_path_result
+
+        # Full LLM classification — only when enabled and fast-path didn't already trigger
+        if self._use_llm and self._llm_classifier and not skip_llm and llm_result is None:
             try:
                 llm_result = self._llm_classifier.classify(user_input, conversation_history)
                 if llm_result:

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -269,6 +269,22 @@ class RiskClassifier:
             )
             emotional_intensity = self._measure_emotional_intensity(user_input)
 
+        # Safety override: always run keyword check for crisis/harmful even after
+        # high-confidence LLM classification. A confident LLM result of "relationships"
+        # for "fake id" or "hack into" must not prevail — safety-critical misclassifications
+        # are unacceptable regardless of LLM confidence.
+        if domain not in ("crisis", "harmful"):
+            keyword_safety = self._detect_domain(user_input, primary_domain=None, domain_streak=0)
+            if keyword_safety in ("crisis", "harmful"):
+                logger.warning(
+                    "Safety keyword override: LLM said '%s', keywords say '%s' — deferring to keywords",
+                    domain,
+                    keyword_safety,
+                )
+                domain = keyword_safety
+                if domain == "crisis":
+                    emotional_intensity = max(emotional_intensity, 9.0)
+
         # Always use keyword matching for these (LLM doesn't handle them yet)
         dependency_risk = self._assess_dependency(conversation_history)
         emotional_weight, weight_score = self._assess_emotional_weight(user_input)

--- a/tests/test_conversation_quality.py
+++ b/tests/test_conversation_quality.py
@@ -195,13 +195,20 @@ class TestConversationQuality:
         """Fresh ConversationSession per scenario."""
         from unittest.mock import MagicMock
 
+        from models.ai_wellness_guide import WellnessGuide
         from models.conversation_session import ConversationSession
+        from utils.trusted_network import TrustedNetwork
+        from utils.wellness_tracker import WellnessTracker
 
-        mock_tracker = MagicMock()
-        mock_tracker.should_enforce_cooldown.return_value = False
-        mock_tracker.get_dependency_score.return_value = 0.0
-        mock_tracker.get_wellness_summary.return_value = {"sessions_today": 1}
-        self._session = ConversationSession(wellness_tracker=mock_tracker)
+        mock_tracker = MagicMock(spec=WellnessTracker)
+        mock_tracker.should_enforce_cooldown.return_value = (False, "")
+        mock_tracker.should_show_graduation_prompt.return_value = (False, "")
+        mock_tracker.calculate_dependency_signals.return_value = {"dependency_score": 0.0}
+        self._session = ConversationSession(
+            guide=WellnessGuide(),
+            tracker=mock_tracker,
+            network=MagicMock(spec=TrustedNetwork),
+        )
 
     def test_response_quality(self, path, scenario):
         """
@@ -219,7 +226,7 @@ class TestConversationQuality:
 
         for i, turn in enumerate(turns):
             user_input = turn["input"]
-            result = self._session.process_message(user_input, wellness_mode="standard")
+            result = self._session.process_message(user_input)
             response = result.response if hasattr(result, "response") else str(result)
 
             turn_id = f"Turn {i + 1}: '{user_input[:50]}'"

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -3459,18 +3459,18 @@ class TestVoiceTuning:
     # --- Brevity enforcement (16.11.6) ---
 
     def test_brevity_high_risk_truncates(self, guide):
-        """High risk responses should be truncated to ~30 words."""
+        """High risk responses should be truncated to ~20 words."""
         long_response = " ".join(["word"] * 100)
         risk = {"risk_weight": 8.0}
         result = guide._process_response(long_response, "test", risk, is_practical=False)
-        assert len(result.split()) <= 35  # 30 words + "..." token
+        assert len(result.split()) <= 25  # 20 words + "..." token
 
     def test_brevity_medium_risk_truncates(self, guide):
-        """Medium risk responses should be truncated to ~50 words."""
+        """Medium risk responses should be truncated to ~20 words."""
         long_response = " ".join(["word"] * 150)
         risk = {"risk_weight": 5.0}
         result = guide._process_response(long_response, "test", risk, is_practical=False)
-        assert len(result.split()) <= 55  # 50 words + "..." token
+        assert len(result.split()) <= 25  # 20 words + "..." token
 
     def test_brevity_practical_not_truncated(self, guide):
         """Practical mode responses should NOT be truncated."""

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -3459,18 +3459,18 @@ class TestVoiceTuning:
     # --- Brevity enforcement (16.11.6) ---
 
     def test_brevity_high_risk_truncates(self, guide):
-        """High risk responses should be truncated to ~50 words."""
+        """High risk responses should be truncated to ~30 words."""
         long_response = " ".join(["word"] * 100)
         risk = {"risk_weight": 8.0}
         result = guide._process_response(long_response, "test", risk, is_practical=False)
-        assert len(result.split()) <= 55  # 50 + buffer for "..."
+        assert len(result.split()) <= 35  # 30 words + "..." token
 
     def test_brevity_medium_risk_truncates(self, guide):
-        """Medium risk responses should be truncated to ~80 words."""
+        """Medium risk responses should be truncated to ~50 words."""
         long_response = " ".join(["word"] * 150)
         risk = {"risk_weight": 5.0}
         result = guide._process_response(long_response, "test", risk, is_practical=False)
-        assert len(result.split()) <= 85  # 80 + buffer
+        assert len(result.split()) <= 55  # 50 words + "..." token
 
     def test_brevity_practical_not_truncated(self, guide):
         """Practical mode responses should NOT be truncated."""

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -503,7 +503,7 @@ class TestWellnessGuide:
         assert "supportive" in result.lower() or "?" in result  # Asks a question
 
     def test_process_response_passes_safe_content(self, guide):
-        safe = "I understand your concern about AI usage. Let's explore this together."
+        safe = "Here's how it works. Let me break it down step by step."
         risk_assessment = {"risk_weight": 3.0, "domain": "logistics", "emotional_intensity": 2.0}
         result = guide._process_response(safe, "test input", risk_assessment)
         assert result == safe

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -332,7 +332,8 @@ class TestRiskClassifier:
         with patch.object(
             classifier._llm_classifier, "classify", return_value=llm_distress_logistics
         ):
-            result = classifier.classify("I feel completely hopeless right now", [])
+            # Use text that won't match fast_path_crisis (which would bypass the mock)
+            result = classifier.classify("I've been struggling a lot lately and feel stuck", [])
             # Only set if keywords found a non-logistics domain to switch to
             if result["domain"] != "logistics":
                 assert result.get("sanity_check_override") == "distress_present"


### PR DESCRIPTION
## Summary

- All 11 original conversation quality failures resolved (11 → 0)
- 983 tests passing total (918 unit + 65 conversation quality)

## What changed

**Voice filter (`personality.yaml`)**
- 16 new forbidden phrases added (corporate therapy-speak, limitation language, warmth performance)
- Added `"I won't assist in"` - verbose refusal pattern that leaks through

**Harmful detection (`harmful.yaml`, `llm_classifier.yaml`)**
- Added surveillance/account access triggers to harmful domain
- Expanded `fast_path_harmful` from 8 to 22 patterns (fake ID, lock picking, account access, address lookup)

**Safety pipeline (`risk_classifier.py`)**
- Defense-in-depth: keyword safety check now runs after LLM classification for all non-crisis/harmful domains - catches rephrased harmful requests the LLM miscategorises

**Conversation engine (`ai_wellness_guide.py`)**
- `_check_meta_question()`: early-exits "rate yourself" / "was that a good response?" type questions before the LLM runs (prevents 400-word email-continuation responses to a 5-word meta-question)
- `post_harmful_turn` tracking: caps next-turn response at 12 words when a harmful refusal just fired - catches immediate rephrasings
- Post-harmful truncation moved before `is_practical` check - safety cap applies even when rephrasing is classified as logistics
- Reflective-marker override: response containing "who in your life" triggers truncation even if domain was classified as logistics (catches classifier/response disagreement)
- `_truncate_at_sentence_boundary()`: sentence-aware truncation replacing mid-word `...` cuts
- Truncation ceilings tightened: 20 words for all sensitive domains (was 30/50)
- "asking for a friend" added to jailbreak phrases

## Test coverage
- `test_brevity_high_risk_truncates`: updated assertion (20 words, was 30)
- `test_brevity_medium_risk_truncates`: updated assertion (20 words, was 50)
- `test_process_response_passes_safe_content`: updated safe string to voice-correct content