### PR TITLE
docs: update architecture.md for Phase 17.6/17.9

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,12 @@ User Input
     ▼
 ┌─────────────────────────────────────────────┐
 │  7. DEPENDENCY INTERVENTION                 │
+│     Domain gate (Phase 17.9):               │
+│     Practical tasks (logistics domain OR    │
+│     is_practical_technique=true) → skip.   │
+│     Coding sessions are help, not           │
+│     dependency. Only reflective domains     │
+│     receive graduated intervention.         │
 │     If dependency_score > threshold:        │
 │     Inject graduated intervention message   │
 └─────────────────────────────────────────────┘
@@ -145,6 +151,11 @@ User Input
 │  PROMPT COMPOSITION                         │
 │     Base rules + Style modifier +           │
 │     Mode-specific rules + Risk context      │
+│     Note (Phase 17.9): is_practical_        │
+│     technique checked alongside             │
+│     domain=='logistics' so technique        │
+│     questions in any domain get full        │
+│     practical prompt, not reflective limits │
 └─────────────────────────────────────────────┘
     │
     ▼
@@ -159,6 +170,16 @@ User Input
 │  SAFETY CHECK                               │
 │     _contains_harmful_content()             │
 │     Verify response is safe before display  │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  RESPONSE MODE LABEL (Phase 17.6)           │
+│     One-line caption under each response:   │
+│     "Responded as: practical task · coding" │
+│     "Responded as: reflective · health"     │
+│     Stored in message dict for rerun        │
+│     persistence (Streamlit rerenders)       │
 └─────────────────────────────────────────────┘
     │
     ▼


### PR DESCRIPTION
## Summary

- **Phase 17.9 - Dependency intervention domain gate**: Step 7 now documents that practical tasks (logistics domain or `is_practical_technique=true`) skip dependency intervention entirely. Coding sessions are help, not dependency.
- **Phase 17.9 - Prompt builder consistency**: Notes that `get_system_prompt()` now checks `is_practical_technique` alongside `domain=='logistics'`, so technique questions in any domain get full practical prompt rules.
- **Phase 17.6 - Response mode label**: Added new step after Safety Check documenting the inline one-line caption under each assistant response, and why it's stored in the message dict (Streamlit rerun persistence).

## Test plan
- [ ] Review pipeline diagram matches current behaviour in `ai_wellness_guide.py` and `wellness_prompts.py`
- [ ] Confirm Response Mode Label step reflects `display_response_mode_label()` in `panels.py`