### PR TITLE
feat: connection steering - persistent arc toward human connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to empathySync are documented here.
 
+## Unreleased
+
+### Phase 16.13 - Conversational Connection Steering
+
+When a user expresses isolation ("there is no one really", "I have nobody", "I manage alone"), empathySync now enters a persistent session-level steering mode that carries a thread toward human connection in every subsequent response. The same conversational mechanics used by engagement algorithms - but pointed at human connection over AI dependency.
+
+**New feature: five-stage steering arc**
+- Stage 0 (Recognition): Acknowledge the isolation signal quietly at the end of the response. One sentence. No solutions, no rush.
+- Stage 1 (Exploration): Ask one genuine question about their connection landscape.
+- Stage 2 (Mapping): Surface any connections mentioned in conversation, however weak (acquaintances, colleagues, old contacts).
+- Stage 3 (Possibility): Offer one small, specific, low-stakes possibility for connection.
+- Stage 4 (Practical Help): Full practical capability turned toward the act of reaching out - drafting messages, preparing conversations, finding words.
+
+**Deflection handling**: Respects user autonomy. If the user consistently stays on practical tasks without engaging the connection thread, the steering suspends after 3 deflections. Never forces the topic over the task.
+
+**Dual isolation detection**:
+- Keyword fast-path: 34 direct+passive isolation phrases detected before LLM call, steering context injected into the current response immediately
+- LLM-detected: New `isolation_level` field in LLM classification JSON (`none` / `passive` / `active`) catches nuanced cases, activates steering on next turn
+
+**CLI fix**: Fixed pre-existing `NameError: settings not defined` in `main()` when `--version` flag is used (settings was imported only inside `run_maintenance()`, not in scope for `main()`).
+
+---
+
 ## v1.9.0 (2026-04-26) - Model Benchmark & Test Reliability
 
 **"Know which model to run. Know your tests are telling the truth."**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1742,6 +1742,49 @@ src/ui/
 
 ---
 
+## Phase 16.13: Conversational Connection Steering ✅ COMPLETE
+
+**Goal**: When any isolation signal is detected ("there is no one really", "I have nobody", "I manage alone"), activate a persistent session-level steering mode that carries a thread toward human connection in every subsequent response. Same machinery as engagement algorithms, opposite goal: human connection over AI dependency.
+
+**Why now**: NHS scenario revealed a hard gap - a user expressing profound isolation ("there is no one really") while asking for practical help received a transactional response with no acknowledgment. The system had a defensive patch (don't suggest humans who don't exist) but no active steering. This feature replaces the patch with a principled five-stage arc.
+
+**Core design insight**: Treat human connection the same way engagement algorithms treat retention. Every isolation signal activates a cross-turn steering mode. Persistent but not pushy - respects user pace, suspends on repeated deflection, never forces the topic over the task.
+
+### Five-Stage Steering Arc
+
+| Stage | Name | Behavior |
+|-------|------|----------|
+| 0 | Recognition | Acknowledge isolation quietly at the end of the response. One sentence. No solutions. |
+| 1 | Exploration | Ask one genuine question about their connection landscape. |
+| 2 | Mapping | Surface any connections mentioned (even weak ties, acquaintances). |
+| 3 | Possibility | Offer one small, specific, low-stakes possibility for connection. |
+| 4 | Practical Help | Full practical capability turned toward the act of reaching out. |
+
+**Deflection handling**: If user consistently returns to practical tasks without engaging the connection thread, deflection count increments. After `max_deflections` (default 3), steering suspends out of respect for autonomy.
+
+**Dual detection**:
+- Keyword fast-path: 34 direct+passive isolation phrases caught before LLM call, so steering context is injected into the current response immediately
+- LLM-detected: `isolation_level` field added to LLM classification output for nuanced cases (passive signals), activates on next turn
+
+### Files Changed
+
+**Created**:
+- `scenarios/connection_building/steering_prompts.yaml` - Stage definitions, isolation signals, deflection instructions, voice for each stage
+
+**Modified**:
+- `src/models/data_contracts.py` - Added `isolation_detected: bool` and `isolation_level: str` to `LLMClassification` with `_VALID_ISOLATION_LEVELS` validation
+- `scenarios/classification/llm_classifier.yaml` - Added `isolation_level` to prompt and return JSON; 3 new few-shot isolation examples
+- `src/models/llm_classifier.py` - Parse and validate `isolation_level`/`isolation_detected` in `_validate_classification()`; fast-path returns include new fields
+- `src/utils/scenario_loader.py` - Added 6 new methods: `get_connection_steering_config()`, `get_isolation_signals()`, `get_connection_steering_stages()`, `get_connection_steering_stage()`, `get_steering_deflection_instruction()`, `get_steering_turns_per_stage()`, `get_steering_max_deflections()`
+- `src/models/conversation_session.py` - Added `ConnectionSteering` dataclass (state machine with `activate()` and `record_turn()`); integrated into `process_message()`, `process_message_stream()`, `finalize_stream()`, `reset()`; added `_check_isolation_signals()` keyword fast-path
+- `src/prompts/wellness_prompts.py` - Added `connection_steering` parameter to `get_system_prompt()`; added `_get_connection_steering_addition()` method
+- `src/models/ai_wellness_guide.py` - Added `connection_steering` parameter to `_prepare_response()`, `generate_response()`, `generate_response_stream()`; replaced crude isolation_context guard with steering-aware injection
+- `src/cli.py` - Fixed `NameError: settings not defined` in `main()` (pre-existing bug uncovered by PR #91)
+- `tests/test_data_contracts.py` - Added 8 isolation field tests; updated `test_to_dict_has_all_fields`
+- `tests/test_conversation_session.py` - Added `ConnectionSteering` dataclass tests (8 tests); added steering integration tests (6 tests); updated `test_guide_called_with_correct_args` and `test_guide_stream_called_with_correct_args`
+
+---
+
 ## Phase 17: Classification Robustness & Safety Evaluation 🔧 IN PROGRESS
 
 **Goal**: Move from single-label classification to multi-signal safety routing, add calibrated confidence handling, and build a regression test suite of real distress phrasing. Ensure false negatives on distress detection are systematically caught before they reach users.

--- a/scenarios/classification/llm_classifier.yaml
+++ b/scenarios/classification/llm_classifier.yaml
@@ -86,8 +86,13 @@ prompt_template: |
   - distress_level: "high" = significant distress, user struggling
   - distress_level: "crisis" = immediate danger, suicidal ideation, self-harm
 
+  Also assess isolation level - whether the user has expressed having no human support:
+  - isolation_level: "none" = no isolation expressed
+  - isolation_level: "passive" = hints at being alone ("I manage alone", "people moved away", "no one really", "not really close to anyone")
+  - isolation_level: "active" = direct statements ("I have nobody", "no one to talk to", "there is no one", "I'm completely alone", "nobody understands me")
+
   Return JSON:
-  {{"domain": "...", "emotional_intensity": 0-10, "is_personal_distress": true/false, "is_practical_technique": true/false, "confidence": 0.0-1.0, "distress_level": "none|low|moderate|high|crisis"}}
+  {{"domain": "...", "emotional_intensity": 0-10, "is_personal_distress": true/false, "is_practical_technique": true/false, "confidence": 0.0-1.0, "distress_level": "none|low|moderate|high|crisis", "isolation_level": "none|passive|active"}}
 
 # Few-shot examples for better accuracy
 examples:
@@ -396,6 +401,37 @@ examples:
       is_practical_technique: false
       confidence: 0.9
     explanation: "Genuine health concern - chronic symptoms unrelated to the practical task. This IS a real domain shift."
+
+  # Isolation detection examples
+  - message: "I could get a mentor or something but there is no one really"
+    classification:
+      domain: "logistics"
+      emotional_intensity: 4
+      is_personal_distress: true
+      is_practical_technique: false
+      confidence: 0.85
+      isolation_level: "active"
+    explanation: "Practical context but contains direct isolation signal. isolation_level active."
+
+  - message: "I just manage these things alone, always have"
+    classification:
+      domain: "emotional"
+      emotional_intensity: 5
+      is_personal_distress: true
+      is_practical_technique: false
+      confidence: 0.85
+      isolation_level: "passive"
+    explanation: "Passive isolation signal - not dramatic but expressing a persistent aloneness."
+
+  - message: "there is no one really, I lost touch with most people"
+    classification:
+      domain: "emotional"
+      emotional_intensity: 7
+      is_personal_distress: true
+      is_practical_technique: false
+      confidence: 0.95
+      isolation_level: "active"
+    explanation: "Direct active isolation - clear absence of support network."
 
 # Keywords that ALWAYS trigger fast-path (safety-critical, skip LLM)
 # These bypass LLM classification entirely for safety

--- a/scenarios/connection_building/steering_prompts.yaml
+++ b/scenarios/connection_building/steering_prompts.yaml
@@ -1,0 +1,161 @@
+# Connection Steering - Persistent conversational steering toward human connection
+#
+# When isolation is detected ("there is no one really", "I have nobody", etc.),
+# this activates a session-level steering mode. Every subsequent response carries
+# a thread back toward human connection. The same mechanics engagement algorithms
+# use for retention - but pointed at human connection, not AI dependency.
+#
+# The arc moves through five stages over the session. It is persistent but not
+# pushy - respects the user's pace and never forces the topic.
+
+isolation_signals:
+  # Direct signals - unambiguous statements of having no one
+  direct:
+    - "there is no one"
+    - "there's no one"
+    - "i have no one"
+    - "have no one"
+    - "nobody to talk to"
+    - "no one to talk to"
+    - "i'm completely alone"
+    - "completely alone"
+    - "i have nobody"
+    - "i've got nobody"
+    - "don't have anyone"
+    - "nobody understands"
+    - "no one understands"
+    - "i've lost everyone"
+    - "i'm isolated"
+    - "no family"
+    - "no friends"
+    - "all alone"
+    - "i'm alone"
+    - "no one really"
+
+  # Passive signals - softer expressions that hint at connection void
+  passive:
+    - "i manage alone"
+    - "i deal with it alone"
+    - "i do it by myself"
+    - "people moved away"
+    - "we drifted apart"
+    - "i stopped reaching out"
+    - "i pushed everyone away"
+    - "not really anyone"
+    - "not really close to anyone"
+    - "lost touch"
+    - "i've lost touch"
+    - "no one really"
+    - "not really"
+
+steering:
+  # How many turns to spend in each stage before auto-advancing
+  turns_per_stage: 2
+
+  # How many turns where user stays on practical task (no connection engagement)
+  # before steering is suspended out of respect for their autonomy
+  max_deflections: 3
+
+  stages:
+    # Stage 0: Recognition
+    # Acknowledge quietly. Don't dwell. Plant a seed.
+    - name: recognition
+      description: "Acknowledge the isolation signal without making it the whole conversation."
+      system_prompt_addition: |
+        ## CONNECTION STEERING ACTIVE - RECOGNITION STAGE
+        Earlier in this conversation, the user indicated they have little or no human support.
+
+        In this response:
+        - Complete whatever practical task or question they have first, fully
+        - At the end, add one brief, honest acknowledgment of the isolation they mentioned
+        - Do NOT say "talk to someone" or "reach out to a friend" - they just said there is no one
+        - Do NOT turn the conversation toward this - it was a small moment, honor its scale
+        - Do NOT ask probing questions yet - just notice it plainly
+        - One sentence is enough. Tone: quiet, direct, not therapeutic
+        - Example: "Also - that bit about there being no one around. I noticed that."
+        - Then stop. Do not explain or elaborate.
+
+    # Stage 1: Exploration
+    # Open gentle curiosity. No assumptions. One question.
+    - name: exploration
+      description: "Understand their connection landscape. Genuine curiosity, no diagnosis."
+      system_prompt_addition: |
+        ## CONNECTION STEERING ACTIVE - EXPLORATION STAGE
+        The user has expressed isolation. You have acknowledged it. Now, if a natural moment allows:
+
+        - Ask one genuine question to understand their situation better
+        - Not to diagnose - to understand
+        - Examples: "Is this a recent thing, or has it always been like this?"
+          "When you say no one - is that geography, or something else?"
+          "What does your week actually look like, in terms of people?"
+        - Only ask if it fits naturally. If they're deep in a practical task, finish that first.
+        - One question only. Do not list multiple questions.
+        - If they answer, listen to what they say - it will shape the next stage.
+
+    # Stage 2: Mapping
+    # Notice any connection threads they've mentioned, however thin.
+    - name: mapping
+      description: "Surface any connections mentioned in conversation, however weak. Reflect gently."
+      system_prompt_addition: |
+        ## CONNECTION STEERING ACTIVE - MAPPING STAGE
+        The user is isolated and you have been in dialogue about that. Now look back at the conversation:
+
+        - If they mentioned ANYONE at all (a manager, colleague, neighbour, old contact), surface it:
+          "You mentioned [person] earlier - what is that relationship like?"
+        - Weak ties count. Acquaintances count. Even difficult relationships are connections.
+        - If they mentioned no one: "When you think about your week, is there anyone you cross paths
+          with, even briefly? Doesn't have to be close."
+        - Frame this as genuine interest, not homework
+        - Keep it brief - one reflection or one question
+        - Complete their current request first, then add this at the end
+
+    # Stage 3: Possibility
+    # One small, real action. Not a life plan.
+    - name: possibility
+      description: "Offer one specific, low-stakes possibility for connection."
+      system_prompt_addition: |
+        ## CONNECTION STEERING ACTIVE - POSSIBILITY STAGE
+        The user is isolated and you have been exploring that together. Now offer one concrete possibility:
+
+        - One specific action - not "join a club" (vague), something actually doable
+        - Examples: "Is there anyone from your past you have been meaning to message but haven't?"
+          "Would it help to have something drafted for that conversation?"
+          "That person you mentioned earlier - is reaching out an option?"
+        - Frame as a possibility, not a prescription: "This might not fit, but..."
+        - If they mentioned specific people or relationships, tie the suggestion to those
+        - Do not lecture about why connection matters. They know.
+        - Do not make it a big moment. Keep it light.
+
+    # Stage 4: Practical help
+    # empathySync's core strength, turned toward human connection.
+    - name: practical_help
+      description: "Offer concrete practical help with the act of reaching out."
+      system_prompt_addition: |
+        ## CONNECTION STEERING ACTIVE - PRACTICAL HELP STAGE
+        The user is open to taking a step toward connection. This is empathySync's strength.
+
+        - Offer to help with the practical act: drafting a message, preparing for a conversation,
+          writing something difficult, planning what to say
+        - Examples: "Want me to help draft something to send to [person]?"
+          "I can help you write that. What is the situation between you two?"
+          "Tell me what you want them to know and I will help you find the words."
+        - Full practical mode: no word limits, use formatting if it helps, be thorough
+        - This is the goal of the steering arc. Bring full capability to this.
+
+  deflection_handling:
+    # These are instructions injected when user deflects back to practical task
+    first: |
+      [The user has returned to a practical task. Complete it fully and well.
+      Do not steer back this turn - let them lead. The thread remains open.]
+    second: |
+      [The user has stayed on the practical track. Complete the task.
+      If a genuinely natural moment opens, you may reference the connection topic
+      once more - very briefly. If no such moment exists, do not force one.]
+    third: |
+      [The user has consistently chosen the practical track. Respect that fully.
+      Drop the steering. Complete whatever they ask without returning to the
+      connection topic. Their autonomy takes precedence.]
+
+  session_end_note:
+    active: "Connection steering was active this session. Isolation detected and sustained steering applied."
+    dormant: "Isolation was detected but user consistently returned to practical tasks. Steering suspended."

--- a/src/cli.py
+++ b/src/cli.py
@@ -120,6 +120,9 @@ def run_maintenance():
 
 def main():
     """Main entry point with mode selection."""
+    sys.path.append(str(Path(__file__).parent))
+    from config.settings import settings
+
     parser = argparse.ArgumentParser(description="empathySync - Help that knows when to stop")
     parser.add_argument(
         "--mode",
@@ -132,12 +135,11 @@ def main():
         action="store_true",
         help="Run maintenance tasks (prune data, check integrity) and exit",
     )
-    
     parser.add_argument(
         "--version",
         action="version",
         version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
-        help="Show the application version and exit"
+        help="Show the application version and exit",
     )
 
     args = parser.parse_args()

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -225,6 +225,7 @@ class WellnessGuide:
         wellness_mode: str = "Balanced",
         conversation_history: List[Dict] = None,
         wellness_tracker=None,
+        connection_steering=None,
     ) -> PreparedResponse:
         """
         Run the pre-LLM safety pipeline and compose the prompt.
@@ -506,7 +507,11 @@ class WellnessGuide:
             return prepared
 
         # 6) Build prompt and generate response
-        system_prompt = self.prompts.get_system_prompt(wellness_mode, risk_context=risk_assessment)
+        system_prompt = self.prompts.get_system_prompt(
+            wellness_mode,
+            risk_context=risk_assessment,
+            connection_steering=connection_steering,
+        )
         conversation_context = self._build_context(conversation_history)
 
         # Check if this is a practical task
@@ -520,9 +525,12 @@ class WellnessGuide:
                 "\n\n[Remember: Include a brief reminder that you are software, not a person.]"
             )
 
-        # Detect isolation signals — stop redirecting to humans who don't exist
+        # Isolation context: when steering is NOT active, apply the defensive guard
+        # (don't suggest humans who don't exist). When steering IS active, the
+        # stage-specific addition in system_prompt already handles the response.
         isolation_context = ""
-        if not is_practical and self._user_expressed_isolation(conversation_history):
+        steering_active = connection_steering is not None and connection_steering.active
+        if not steering_active and self._user_expressed_isolation(conversation_history):
             isolation_context = (
                 "\n\n[IMPORTANT: The user has said they have no one to talk to. "
                 "Do NOT suggest 'who in your life could you talk to' or similar. "
@@ -618,6 +626,7 @@ class WellnessGuide:
         wellness_mode: str = "Balanced",
         conversation_history: List[Dict] = None,
         wellness_tracker=None,
+        connection_steering=None,
     ) -> str:
         """
         Generate empathetic response with full safety pipeline.
@@ -633,7 +642,11 @@ class WellnessGuide:
         """
         try:
             prepared = self._prepare_response(
-                user_input, wellness_mode, conversation_history, wellness_tracker
+                user_input,
+                wellness_mode,
+                conversation_history,
+                wellness_tracker,
+                connection_steering=connection_steering,
             )
 
             if prepared.early_return:
@@ -656,6 +669,7 @@ class WellnessGuide:
         wellness_mode: str = "Balanced",
         conversation_history: List[Dict] = None,
         wellness_tracker=None,
+        connection_steering=None,
     ) -> Generator[str, None, None]:
         """
         Stream empathetic response tokens with full safety pipeline.
@@ -669,7 +683,11 @@ class WellnessGuide:
         """
         try:
             prepared = self._prepare_response(
-                user_input, wellness_mode, conversation_history, wellness_tracker
+                user_input,
+                wellness_mode,
+                conversation_history,
+                wellness_tracker,
+                connection_steering=connection_steering,
             )
 
             if prepared.early_return:

--- a/src/models/conversation_session.py
+++ b/src/models/conversation_session.py
@@ -10,6 +10,7 @@ can import to get safety-aware, restraint-first conversation handling.
 
 import random
 import logging
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from models.ai_wellness_guide import WellnessGuide
@@ -26,6 +27,46 @@ from utils.trusted_network import TrustedNetwork
 from utils.scenario_loader import get_scenario_loader
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConnectionSteering:
+    """
+    Session-level state for connection steering.
+
+    When isolation is detected ("there is no one really"), this activates and
+    persists across turns, injecting stage-appropriate steering context into
+    each subsequent response. Advances through five stages automatically.
+    Suspends if the user consistently deflects back to practical tasks.
+    """
+
+    active: bool = False
+    stage: int = 0  # 0=recognition, 1=exploration, 2=mapping, 3=possibility, 4=practical_help
+    turns_in_stage: int = 0
+    deflection_count: int = 0
+    consecutive_deflections: int = 0
+    first_detected_turn: int = 0
+
+    def record_turn(self, is_deflection: bool, turns_per_stage: int, max_deflections: int) -> None:
+        """Update state after each active-steering turn."""
+        if is_deflection:
+            self.deflection_count += 1
+            self.consecutive_deflections += 1
+            if self.deflection_count >= max_deflections:
+                self.active = False
+                return
+        else:
+            self.consecutive_deflections = 0
+
+        self.turns_in_stage += 1
+        if self.turns_in_stage >= turns_per_stage and self.stage < 4:
+            self.stage += 1
+            self.turns_in_stage = 0
+
+    def activate(self, turn_count: int) -> None:
+        """Activate steering, recording when it was first triggered."""
+        self.active = True
+        self.first_detected_turn = turn_count
 
 
 def _load_confidence_threshold() -> float:
@@ -77,6 +118,9 @@ class ConversationSession:
         # Handoff state
         self.pending_handoff_for_outcome: Optional[str] = None
         self.pending_handoff_info: Optional[Dict] = None
+
+        # Connection steering state
+        self.connection_steering = ConnectionSteering()
 
     @property
     def turn_count(self) -> int:
@@ -156,15 +200,39 @@ class ConversationSession:
             if shift and shift.get("is_concerning"):
                 self.pending_shift = shift
 
+        # Step 3.5: Isolation detection - keyword fast-path before LLM call
+        # so steering context can be injected into this response immediately.
+        if not self.connection_steering.active:
+            if self._check_isolation_signals(user_input):
+                self.connection_steering.activate(self.turn_count)
+
         # Step 4: Generate response via WellnessGuide safety pipeline
         response = self.guide.generate_response(
             user_input,
             self.wellness_mode,
             self.messages,
             wellness_tracker=self.tracker,
+            connection_steering=self.connection_steering,
         )
 
         self.messages.append({"role": "assistant", "content": response})
+
+        # Step 4.5: Post-response isolation checks
+        # Check LLM-detected isolation (for cases keyword fast-path missed)
+        if not self.connection_steering.active and self.guide.last_risk_assessment:
+            isolation_level = self.guide.last_risk_assessment.get("isolation_level", "none")
+            if isolation_level in ("active", "passive"):
+                self.connection_steering.activate(self.turn_count)
+
+        # Update steering state for next turn
+        if self.connection_steering.active:
+            domain = ""
+            if self.guide.last_risk_assessment:
+                domain = self.guide.last_risk_assessment.get("domain", "")
+            turns_per_stage = self.loader.get_steering_turns_per_stage()
+            max_deflections = self.loader.get_steering_max_deflections()
+            is_deflection = domain == "logistics" and self.connection_steering.stage < 4
+            self.connection_steering.record_turn(is_deflection, turns_per_stage, max_deflections)
 
         # Step 5: Track task category for practical tasks
         should_check_graduation = False
@@ -293,12 +361,18 @@ class ConversationSession:
             if shift and shift.get("is_concerning"):
                 self.pending_shift = shift
 
+        # Step 3.5: Isolation detection - keyword fast-path before LLM call
+        if not self.connection_steering.active:
+            if self._check_isolation_signals(user_input):
+                self.connection_steering.activate(self.turn_count)
+
         # Step 4: Get streaming generator from WellnessGuide
         stream = self.guide.generate_response_stream(
             user_input,
             self.wellness_mode,
             self.messages,
             wellness_tracker=self.tracker,
+            connection_steering=self.connection_steering,
         )
 
         # Store user_input for finalize_stream
@@ -326,6 +400,22 @@ class ConversationSession:
 
         # Add to message history
         self.messages.append({"role": "assistant", "content": response})
+
+        # Post-response isolation checks (LLM-detected, for next turn)
+        if not self.connection_steering.active and self.guide.last_risk_assessment:
+            isolation_level = self.guide.last_risk_assessment.get("isolation_level", "none")
+            if isolation_level in ("active", "passive"):
+                self.connection_steering.activate(self.turn_count)
+
+        # Update steering state
+        if self.connection_steering.active:
+            domain = ""
+            if self.guide.last_risk_assessment:
+                domain = self.guide.last_risk_assessment.get("domain", "")
+            turns_per_stage = self.loader.get_steering_turns_per_stage()
+            max_deflections = self.loader.get_steering_max_deflections()
+            is_deflection = domain == "logistics" and self.connection_steering.stage < 4
+            self.connection_steering.record_turn(is_deflection, turns_per_stage, max_deflections)
 
         # Step 5: Track task category for practical tasks
         should_check_graduation = False
@@ -386,6 +476,12 @@ class ConversationSession:
             should_rerun=should_rerun,
         )
 
+    def _check_isolation_signals(self, text: str) -> bool:
+        """Check text for isolation signals using keyword fast-path list from YAML."""
+        signals = self.loader.get_isolation_signals()
+        text_lower = text.lower()
+        return any(signal in text_lower for signal in signals)
+
     def acknowledge_intent_shift(self, accept_shift: bool) -> None:
         """User responded to intent shift prompt."""
         if accept_shift and self.pending_shift:
@@ -421,4 +517,5 @@ class ConversationSession:
         self.last_task_category = None
         self.pending_handoff_for_outcome = None
         self.pending_handoff_info = None
+        self.connection_steering = ConnectionSteering()
         self.guide.reset_session()

--- a/src/models/data_contracts.py
+++ b/src/models/data_contracts.py
@@ -88,8 +88,11 @@ class LLMClassification:
     classification_method: str = "llm"
     distress_present: bool = False
     distress_level: str = "none"
+    isolation_detected: bool = False
+    isolation_level: str = "none"
 
     _VALID_DISTRESS_LEVELS = frozenset({"none", "low", "moderate", "high", "crisis"})
+    _VALID_ISOLATION_LEVELS = frozenset({"none", "passive", "active"})
 
     def __post_init__(self):
         self.emotional_intensity = max(0.0, min(10.0, float(self.emotional_intensity)))
@@ -98,6 +101,10 @@ class LLMClassification:
             self.distress_level = "none"
         if self.distress_level != "none":
             self.distress_present = True
+        if self.isolation_level not in self._VALID_ISOLATION_LEVELS:
+            self.isolation_level = "none"
+        if self.isolation_level != "none":
+            self.isolation_detected = True
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)

--- a/src/models/llm_classifier.py
+++ b/src/models/llm_classifier.py
@@ -159,6 +159,8 @@ class LLMClassifier:
                     "classification_method": "fast_path_crisis",
                     "distress_level": "crisis",
                     "distress_present": True,
+                    "isolation_level": "none",
+                    "isolation_detected": False,
                 }
 
         # Check harmful patterns
@@ -174,6 +176,8 @@ class LLMClassifier:
                     "classification_method": "fast_path_harmful",
                     "distress_level": "none",
                     "distress_present": False,
+                    "isolation_level": "none",
+                    "isolation_detected": False,
                 }
 
         return None
@@ -304,6 +308,15 @@ class LLMClassifier:
             distress_level = "none"
         distress_present = distress_level != "none"
 
+        # Isolation level (connection steering)
+        valid_isolation_levels = {"none", "passive", "active"}
+        isolation_level = result.get("isolation_level", "none")
+        if isinstance(isolation_level, str):
+            isolation_level = isolation_level.lower()
+        if isolation_level not in valid_isolation_levels:
+            isolation_level = "none"
+        isolation_detected = isolation_level != "none"
+
         return {
             "domain": domain,
             "emotional_intensity": intensity,
@@ -313,6 +326,8 @@ class LLMClassifier:
             "classification_method": "llm",
             "distress_level": distress_level,
             "distress_present": distress_present,
+            "isolation_level": isolation_level,
+            "isolation_detected": isolation_detected,
         }
 
     def _call_ollama(self, prompt: str) -> Optional[str]:

--- a/src/prompts/wellness_prompts.py
+++ b/src/prompts/wellness_prompts.py
@@ -29,7 +29,9 @@ class WellnessPrompts:
         """
         self.loader = scenario_loader or get_scenario_loader()
 
-    def get_system_prompt(self, wellness_mode: str, risk_context: Dict = None) -> str:
+    def get_system_prompt(
+        self, wellness_mode: str, risk_context: Dict = None, connection_steering=None
+    ) -> str:
         """
         Build a complete system prompt with:
         1. Base behavioral rules (always applied)
@@ -67,6 +69,12 @@ class WellnessPrompts:
         elif risk_context:
             risk_instructions = self._get_risk_instructions(risk_context)
             prompt_parts.append(risk_instructions)
+
+        # Add connection steering context (cross-cutting - applies in any mode)
+        if connection_steering and connection_steering.active:
+            steering_addition = self._get_connection_steering_addition(connection_steering)
+            if steering_addition:
+                prompt_parts.append(steering_addition)
 
         return "\n\n".join(prompt_parts)
 
@@ -212,6 +220,25 @@ If the user asks for advice on: {forbidden_text}—respond ONLY with:
                     instructions.append(f"DEPENDENCY INTERVENTION: {instruction}")
 
         return "\n".join(instructions)
+
+    def _get_connection_steering_addition(self, connection_steering) -> str:
+        """
+        Get stage-specific steering context for active connection steering.
+
+        When isolation is detected, each response gets a stage-appropriate
+        instruction block that guides the LLM to carry a thread toward
+        human connection - without overriding the primary response.
+        """
+        if connection_steering.deflection_count > 0:
+            # Inject deflection-specific instruction instead of stage prompt
+            deflection_instruction = self.loader.get_steering_deflection_instruction(
+                connection_steering.deflection_count
+            )
+            if deflection_instruction:
+                return deflection_instruction.strip()
+
+        stage_config = self.loader.get_connection_steering_stage(connection_steering.stage)
+        return stage_config.get("system_prompt_addition", "").strip()
 
     def get_check_in_prompts(self) -> List[str]:
         """Get various check-in prompts for user reflection."""

--- a/src/utils/scenario_loader.py
+++ b/src/utils/scenario_loader.py
@@ -1244,6 +1244,49 @@ class ScenarioLoader:
             return random.choice(affirmations)
         return "Finding connection as an adult is genuinely difficult. You're not broken for struggling with it."
 
+    # ==================== CONNECTION STEERING ====================
+
+    def get_connection_steering_config(self) -> Dict:
+        """Get the full connection steering configuration."""
+        connection = self.get_all_connection_building()
+        return connection.get("steering_prompts", {})
+
+    def get_isolation_signals(self) -> List[str]:
+        """Get all isolation signal phrases (direct + passive) for keyword detection."""
+        config = self.get_connection_steering_config()
+        signals = config.get("isolation_signals", {})
+        return signals.get("direct", []) + signals.get("passive", [])
+
+    def get_connection_steering_stages(self) -> List[Dict]:
+        """Get the ordered list of steering stage configurations."""
+        config = self.get_connection_steering_config()
+        return config.get("steering", {}).get("stages", [])
+
+    def get_connection_steering_stage(self, stage_index: int) -> Dict:
+        """Get configuration for a specific steering stage."""
+        stages = self.get_connection_steering_stages()
+        if 0 <= stage_index < len(stages):
+            return stages[stage_index]
+        return {}
+
+    def get_steering_deflection_instruction(self, deflection_count: int) -> str:
+        """Get the system prompt instruction for nth deflection (1-indexed)."""
+        config = self.get_connection_steering_config()
+        deflection_config = config.get("steering", {}).get("deflection_handling", {})
+        keys = ["first", "second", "third"]
+        idx = min(deflection_count - 1, len(keys) - 1)
+        return deflection_config.get(keys[idx], "") if 0 <= idx < len(keys) else ""
+
+    def get_steering_turns_per_stage(self) -> int:
+        """Get the configured turns per stage before auto-advancing."""
+        config = self.get_connection_steering_config()
+        return config.get("steering", {}).get("turns_per_stage", 2)
+
+    def get_steering_max_deflections(self) -> int:
+        """Get the configured max deflections before steering is suspended."""
+        config = self.get_connection_steering_config()
+        return config.get("steering", {}).get("max_deflections", 3)
+
     # ==================== UTILITY METHODS ====================
 
     def clear_cache(self) -> None:

--- a/tests/test_conversation_session.py
+++ b/tests/test_conversation_session.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from models.conversation_session import ConversationSession
+from models.conversation_session import ConversationSession, ConnectionSteering
 from models.conversation_result import ConversationResult
 
 
@@ -74,6 +74,14 @@ def mock_loader():
     loader.get_graduation_category.return_value = None
     loader.get_graduation_settings.return_value = {"max_dismissals": 3}
     loader.get_graduation_prompts.return_value = []
+    loader.get_isolation_signals.return_value = [
+        "there is no one",
+        "i have no one",
+        "nobody to talk to",
+        "no one really",
+    ]
+    loader.get_steering_turns_per_stage.return_value = 2
+    loader.get_steering_max_deflections.return_value = 3
     return loader
 
 
@@ -206,6 +214,7 @@ class TestProcessMessage:
             "Balanced",
             session.messages,
             wellness_tracker=session.tracker,
+            connection_steering=session.connection_steering,
         )
 
     def test_result_includes_risk_assessment(self, session, mock_guide):
@@ -531,6 +540,7 @@ class TestProcessMessageStream:
             "Balanced",
             session.messages,
             wellness_tracker=session.tracker,
+            connection_steering=session.connection_steering,
         )
 
     def test_stream_cooldown_returns_early(self, session, mock_tracker, mock_guide):
@@ -808,3 +818,141 @@ class TestConversationResultDataclass:
         assert result.cooldown_message == "Too many sessions"
         assert result.turn_count == 5
         assert result.should_rerun is True
+
+
+# ---------------------------------------------------------------------------
+# ConnectionSteering dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionSteering:
+    """Tests for ConnectionSteering state machine."""
+
+    def test_default_state_is_inactive(self):
+        cs = ConnectionSteering()
+        assert cs.active is False
+        assert cs.stage == 0
+        assert cs.turns_in_stage == 0
+        assert cs.deflection_count == 0
+
+    def test_activate_sets_active_and_turn(self):
+        cs = ConnectionSteering()
+        cs.activate(turn_count=3)
+        assert cs.active is True
+        assert cs.first_detected_turn == 3
+
+    def test_record_turn_increments_turns_in_stage(self):
+        cs = ConnectionSteering(active=True)
+        cs.record_turn(is_deflection=False, turns_per_stage=2, max_deflections=3)
+        assert cs.turns_in_stage == 1
+
+    def test_stage_advances_after_turns_per_stage(self):
+        cs = ConnectionSteering(active=True)
+        cs.record_turn(is_deflection=False, turns_per_stage=2, max_deflections=3)
+        assert cs.stage == 0
+        cs.record_turn(is_deflection=False, turns_per_stage=2, max_deflections=3)
+        assert cs.stage == 1
+        assert cs.turns_in_stage == 0
+
+    def test_stage_does_not_exceed_4(self):
+        cs = ConnectionSteering(active=True, stage=4, turns_in_stage=0)
+        cs.record_turn(is_deflection=False, turns_per_stage=1, max_deflections=3)
+        assert cs.stage == 4  # capped at 4
+
+    def test_deflection_increments_count(self):
+        cs = ConnectionSteering(active=True)
+        cs.record_turn(is_deflection=True, turns_per_stage=2, max_deflections=3)
+        assert cs.deflection_count == 1
+        assert cs.active is True
+
+    def test_max_deflections_deactivates_steering(self):
+        cs = ConnectionSteering(active=True)
+        cs.record_turn(is_deflection=True, turns_per_stage=2, max_deflections=3)
+        cs.record_turn(is_deflection=True, turns_per_stage=2, max_deflections=3)
+        cs.record_turn(is_deflection=True, turns_per_stage=2, max_deflections=3)
+        assert cs.active is False
+
+    def test_non_deflection_resets_consecutive_deflections(self):
+        cs = ConnectionSteering(active=True, consecutive_deflections=2)
+        cs.record_turn(is_deflection=False, turns_per_stage=2, max_deflections=3)
+        assert cs.consecutive_deflections == 0
+
+
+# ---------------------------------------------------------------------------
+# Connection steering integration in ConversationSession
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionSteeringIntegration:
+    """Tests for isolation detection and steering activation in ConversationSession."""
+
+    def test_isolation_not_active_by_default(self, session):
+        assert session.connection_steering.active is False
+
+    def test_check_isolation_signals_direct_match(self, session):
+        assert session._check_isolation_signals("there is no one to help me") is True
+
+    def test_check_isolation_signals_no_match(self, session):
+        assert session._check_isolation_signals("help me write an email") is False
+
+    def test_isolation_activates_steering_in_process_message(
+        self, session, mock_guide, mock_loader, mock_classifier
+    ):
+        mock_guide.generate_response.return_value = "Here's some help."
+        mock_guide.last_risk_assessment = {"domain": "logistics", "isolation_level": "none"}
+        mock_guide.last_policy_action = None
+        mock_classifier.is_connection_seeking.return_value = (False, None)
+        mock_classifier.detect_intent.return_value = ("practical", 0.8)
+        mock_classifier.detect_intent_shift.return_value = None
+        mock_classifier.detect_task_category.return_value = (None, 0.0)
+        mock_loader.get_graduation_category.return_value = None
+
+        session.process_message("Help me with this task, there is no one I can ask")
+
+        assert session.connection_steering.active is True
+
+    def test_steering_passed_to_generate_response(
+        self, session, mock_guide, mock_loader, mock_classifier
+    ):
+        mock_guide.generate_response.return_value = "Here's some help."
+        mock_guide.last_risk_assessment = {"domain": "logistics", "isolation_level": "none"}
+        mock_guide.last_policy_action = None
+        mock_classifier.is_connection_seeking.return_value = (False, None)
+        mock_classifier.detect_intent.return_value = ("practical", 0.8)
+        mock_classifier.detect_intent_shift.return_value = None
+        mock_classifier.detect_task_category.return_value = (None, 0.0)
+        mock_loader.get_graduation_category.return_value = None
+
+        session.process_message("I have no one to ask. Help me write this email.")
+
+        _, call_kwargs = mock_guide.generate_response.call_args
+        assert "connection_steering" in call_kwargs
+        assert call_kwargs["connection_steering"].active is True
+
+    def test_reset_clears_steering_state(self, session):
+        session.connection_steering.activate(turn_count=1)
+        session.reset()
+        assert session.connection_steering.active is False
+        assert session.connection_steering.stage == 0
+
+    def test_llm_isolation_detection_activates_steering_after_response(
+        self, session, mock_guide, mock_loader, mock_classifier
+    ):
+        """LLM-detected isolation (no keyword match) activates steering for next turn."""
+        mock_guide.generate_response.return_value = "Here's some help."
+        mock_guide.last_risk_assessment = {
+            "domain": "logistics",
+            "isolation_level": "passive",
+        }
+        mock_guide.last_policy_action = None
+        mock_classifier.is_connection_seeking.return_value = (False, None)
+        mock_classifier.detect_intent.return_value = ("practical", 0.8)
+        mock_classifier.detect_intent_shift.return_value = None
+        mock_classifier.detect_task_category.return_value = (None, 0.0)
+        mock_loader.get_graduation_category.return_value = None
+
+        # Message with no keyword match - relies on LLM result
+        session.process_message("I just manage things by myself")
+
+        # Steering activates post-response from LLM result
+        assert session.connection_steering.active is True

--- a/tests/test_data_contracts.py
+++ b/tests/test_data_contracts.py
@@ -603,6 +603,8 @@ class TestLLMClassificationToDict:
             "classification_method",
             "distress_level",
             "distress_present",
+            "isolation_level",
+            "isolation_detected",
         }
         assert set(d.keys()) == expected_keys
 
@@ -759,3 +761,70 @@ class TestEdgeCases:
         assert lc.domain == lc["domain"]
         assert lc.confidence == lc["confidence"]
         assert lc.domain == lc.get("domain")
+
+
+# ---------------------------------------------------------------------------
+# LLMClassification isolation fields (connection steering)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMClassificationIsolationFields:
+    """Tests for isolation_detected and isolation_level fields added for connection steering."""
+
+    def test_defaults_to_no_isolation(self):
+        lc = LLMClassification(domain="logistics", emotional_intensity=0.0)
+        assert lc.isolation_level == "none"
+        assert lc.isolation_detected is False
+
+    def test_active_isolation_sets_detected(self):
+        lc = LLMClassification(
+            domain="emotional", emotional_intensity=7.0, isolation_level="active"
+        )
+        assert lc.isolation_detected is True
+        assert lc.isolation_level == "active"
+
+    def test_passive_isolation_sets_detected(self):
+        lc = LLMClassification(
+            domain="emotional", emotional_intensity=4.0, isolation_level="passive"
+        )
+        assert lc.isolation_detected is True
+        assert lc.isolation_level == "passive"
+
+    def test_none_isolation_does_not_set_detected(self):
+        lc = LLMClassification(domain="logistics", emotional_intensity=0.0, isolation_level="none")
+        assert lc.isolation_detected is False
+
+    def test_invalid_isolation_level_normalized_to_none(self):
+        lc = LLMClassification(
+            domain="logistics", emotional_intensity=0.0, isolation_level="extreme"
+        )
+        assert lc.isolation_level == "none"
+        assert lc.isolation_detected is False
+
+    def test_isolation_detected_explicit_false_overridden_by_active_level(self):
+        """isolation_detected should be derived from isolation_level in __post_init__."""
+        lc = LLMClassification(
+            domain="emotional",
+            emotional_intensity=5.0,
+            isolation_level="active",
+            isolation_detected=False,
+        )
+        assert lc.isolation_detected is True
+
+    def test_to_dict_includes_isolation_fields(self):
+        lc = LLMClassification(
+            domain="emotional", emotional_intensity=5.0, isolation_level="passive"
+        )
+        d = lc.to_dict()
+        assert "isolation_level" in d
+        assert "isolation_detected" in d
+        assert d["isolation_level"] == "passive"
+        assert d["isolation_detected"] is True
+
+    def test_from_dict_roundtrip_with_isolation(self):
+        original = LLMClassification(
+            domain="emotional", emotional_intensity=7.0, isolation_level="active"
+        )
+        rebuilt = LLMClassification.from_dict(original.to_dict())
+        assert rebuilt.isolation_level == "active"
+        assert rebuilt.isolation_detected is True


### PR DESCRIPTION
## Summary

- Implements Phase 16.13: Conversational Connection Steering
- When isolation is detected ("there is no one really", "I have nobody", "I manage alone"), activates a persistent session-level steering mode that carries a thread toward human connection across every subsequent response
- Same conversational mechanics as engagement algorithms - opposite goal: human connection over AI dependency

## The five-stage arc

| Stage | Name | Behaviour |
|-------|------|-----------|
| 0 | Recognition | Acknowledge the isolation signal quietly at end of response. One sentence. |
| 1 | Exploration | Ask one genuine question about their connection landscape. |
| 2 | Mapping | Surface any connections mentioned (weak ties, acquaintances count). |
| 3 | Possibility | Offer one small, specific, low-stakes possibility for connection. |
| 4 | Practical Help | Full capability turned toward drafting messages, preparing conversations. |

Deflection handling: respects autonomy - suspends after 3 deflections.

## What changed

**New file**: `scenarios/connection_building/steering_prompts.yaml` - stage definitions, 34 isolation signal phrases, deflection instructions, voice for each stage

**Data contracts**: Added `isolation_detected: bool` and `isolation_level: str` (`none`/`passive`/`active`) to `LLMClassification` with `_VALID_ISOLATION_LEVELS` validation

**LLM classifier**: `isolation_level` added to prompt template and return JSON; 3 new isolation few-shot examples; fast-path returns include new fields

**Scenario loader**: 6 new methods for steering config access

**ConversationSession**: New `ConnectionSteering` dataclass (state machine); integrated into all pipeline paths (`process_message`, `process_message_stream`, `finalize_stream`, `reset`); `_check_isolation_signals()` keyword fast-path

**WellnessPrompts**: `connection_steering` parameter added to `get_system_prompt()`; `_get_connection_steering_addition()` injects stage-specific context

**WellnessGuide**: `connection_steering` threaded through `_prepare_response()`, `generate_response()`, `generate_response_stream()`; existing crude isolation guard (`isolation_context`) now only applies when steering is inactive

**CLI fix**: Fixed pre-existing `NameError: settings not defined` in `main()` when `--version` flag used (settings was imported only inside `run_maintenance()`)

**Tests**: 14 new tests covering `ConnectionSteering` dataclass state machine, isolation detection, steering activation, steering-to-generate threading, reset behaviour, LLM-detected isolation; updated 3 existing tests to expect new parameters

## Test plan

- [x] All 184 tests in `test_data_contracts.py` and `test_conversation_session.py` pass
- [x] All 357 tests in `test_wellness_guide.py` and `test_llm_classifier.py` pass
- [x] All 4 CLI tests pass (including the `--version` fix)
- [x] Black and flake8 pre-commit hooks pass