### PR TITLE
feat: add per-message response time logging (closes #59)

### DIFF
--- a/src/models/conversation_session.py
+++ b/src/models/conversation_session.py
@@ -9,6 +9,7 @@ can import to get safety-aware, restraint-first conversation handling.
 """
 
 import random
+import time
 import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional
@@ -121,6 +122,8 @@ class ConversationSession:
         Returns:
             ConversationResult with the response and all metadata.
         """
+        t_msg_start = time.perf_counter()
+
         # Add user message to history
         self.messages.append({"role": "user", "content": user_input})
 
@@ -251,6 +254,8 @@ class ConversationSession:
         # Step 8: Build result
         should_rerun = self.guide.last_policy_action is not None or self.pending_shift is not None
 
+        self._log_perf(t_msg_start)
+
         return ConversationResult(
             response=response,
             risk_assessment=self.guide.last_risk_assessment,
@@ -345,8 +350,9 @@ class ConversationSession:
             connection_steering=self.connection_steering,
         )
 
-        # Store user_input for finalize_stream
+        # Store user_input and start time for finalize_stream
         self._pending_stream_input = user_input
+        self._stream_start_time = time.perf_counter()
 
         return ConversationResult(
             response="",
@@ -424,6 +430,8 @@ class ConversationSession:
 
         should_rerun = self.guide.last_policy_action is not None or self.pending_shift is not None
 
+        self._log_perf(getattr(self, "_stream_start_time", time.perf_counter()))
+
         return ConversationResult(
             response=response,
             risk_assessment=self.guide.last_risk_assessment,
@@ -434,6 +442,25 @@ class ConversationSession:
             suggested_handoff_domain=suggested_domain,
             turn_count=self.turn_count,
             should_rerun=should_rerun,
+        )
+
+    def _log_perf(self, t_start: float) -> None:
+        """Emit a structured per-message performance summary at INFO level."""
+        total_s = time.perf_counter() - t_start
+        risk = self.guide.last_risk_assessment or {}
+        domain = risk.get("domain", "unknown")
+        method = risk.get("classification_method", "unknown")
+        llm_clf = getattr(self.guide.risk_classifier, "_llm_classifier", None)
+        classify_s = getattr(llm_clf, "last_call_duration", 0.0) if llm_clf else 0.0
+        generate_s = getattr(self.guide.ollama_client, "last_generate_duration", 0.0)
+        logger.info(
+            "[PERF] turn=%d | classify_s=%.2f | generate_s=%.2f | total_s=%.2f | domain=%s | method=%s",
+            self.turn_count,
+            classify_s,
+            generate_s,
+            total_s,
+            domain,
+            method,
         )
 
     def _check_isolation_signals(self, text: str) -> bool:

--- a/src/models/llm_classifier.py
+++ b/src/models/llm_classifier.py
@@ -10,6 +10,7 @@ Part of Phase 9: LLM-Based Intelligent Classification
 import json
 import re
 import hashlib
+import time
 import httpx
 from datetime import datetime
 from pathlib import Path
@@ -94,6 +95,9 @@ class LLMClassifier:
         # Pre-compile fast-path patterns for efficiency
         self._fast_path_crisis = [p.lower() for p in self.config.get("fast_path_crisis", [])]
         self._fast_path_harmful = [p.lower() for p in self.config.get("fast_path_harmful", [])]
+
+        # Timing instrumentation - duration of last _call_ollama() invocation
+        self.last_call_duration: float = 0.0
 
         model_note = ""
         if settings.OLLAMA_CLASSIFIER_MODEL:
@@ -345,8 +349,15 @@ class LLMClassifier:
 
         try:
             timeout_secs = timeout_ms / 1000
+            t_start = time.perf_counter()
             response = self.http_client.post(self.ollama_url, json=payload, timeout=timeout_secs)
             response.raise_for_status()
+            self.last_call_duration = time.perf_counter() - t_start
+            logger.info(
+                "llm_classifier.call | model=%s | duration_s=%.2f",
+                self.model,
+                self.last_call_duration,
+            )
 
             result = response.json()
             return result.get("response", "").strip()

--- a/src/models/ollama_client.py
+++ b/src/models/ollama_client.py
@@ -44,6 +44,9 @@ class OllamaClient:
         self.model = model or settings.OLLAMA_MODEL
         self.temperature = temperature if temperature is not None else settings.OLLAMA_TEMPERATURE
 
+        # Timing instrumentation - duration of last generate/generate_stream call
+        self.last_generate_duration: float = 0.0
+
         # Load tunables from system_defaults.yaml (falls back to hardcoded defaults)
         loader = get_scenario_loader()
         self.practical_max_tokens = loader.get_default(
@@ -105,6 +108,7 @@ class OllamaClient:
 
             result = response.json()
             text = result.get("response", "").strip()
+            self.last_generate_duration = elapsed
             logger.info(
                 "ollama.generate | model=%s | practical=%s | tokens=%d | duration_s=%.2f",
                 self.model,
@@ -170,6 +174,7 @@ class OllamaClient:
                         yield token
                     if chunk.get("done"):
                         elapsed = time.perf_counter() - t_start
+                        self.last_generate_duration = elapsed
                         logger.info(
                             "ollama.stream | model=%s | practical=%s | tokens=%d | ttft_s=%.2f | duration_s=%.2f",
                             self.model,

--- a/tests/test_conversation_session.py
+++ b/tests/test_conversation_session.py
@@ -915,3 +915,65 @@ class TestConnectionSteeringIntegration:
 
         # Steering activates post-response from LLM result
         assert session.connection_steering.active is True
+
+
+# ---------------------------------------------------------------------------
+# Performance logging
+# ---------------------------------------------------------------------------
+
+
+class TestPerfLogging:
+    """Tests for [PERF] structured log line emitted per message."""
+
+    def test_perf_logged_after_process_message(
+        self, session, mock_guide, mock_loader, mock_classifier
+    ):
+        mock_guide.generate_response.return_value = "Done."
+        mock_guide.last_risk_assessment = {"domain": "logistics", "classification_method": "llm"}
+        mock_guide.last_policy_action = None
+        mock_guide.risk_classifier = MagicMock()
+        mock_guide.risk_classifier._llm_classifier = None
+        mock_guide.ollama_client = MagicMock()
+        mock_guide.ollama_client.last_generate_duration = 1.5
+        mock_classifier.is_connection_seeking.return_value = (False, None)
+        mock_classifier.detect_intent.return_value = ("practical", 0.8)
+        mock_classifier.detect_intent_shift.return_value = None
+        mock_classifier.detect_task_category.return_value = (None, 0.0)
+        mock_loader.get_graduation_category.return_value = None
+
+        import logging
+
+        with patch.object(logging.getLogger("models.conversation_session"), "info") as mock_log:
+            session.process_message("help me write an email")
+
+        logged = [str(c) for c in mock_log.call_args_list]
+        assert any("[PERF]" in msg for msg in logged)
+
+    def test_perf_log_contains_domain_and_method(
+        self, session, mock_guide, mock_loader, mock_classifier
+    ):
+        mock_guide.generate_response.return_value = "Done."
+        mock_guide.last_risk_assessment = {
+            "domain": "emotional",
+            "classification_method": "keyword",
+        }
+        mock_guide.last_policy_action = None
+        mock_guide.risk_classifier = MagicMock()
+        mock_guide.risk_classifier._llm_classifier = None
+        mock_guide.ollama_client = MagicMock()
+        mock_guide.ollama_client.last_generate_duration = 0.5
+        mock_classifier.is_connection_seeking.return_value = (False, None)
+        mock_classifier.detect_intent.return_value = ("emotional", 0.8)
+        mock_classifier.detect_intent_shift.return_value = None
+        mock_classifier.detect_task_category.return_value = (None, 0.0)
+        mock_loader.get_graduation_category.return_value = None
+
+        import logging
+
+        with patch.object(logging.getLogger("models.conversation_session"), "info") as mock_log:
+            session.process_message("I feel sad")
+
+        perf_lines = [str(c) for c in mock_log.call_args_list if "[PERF]" in str(c)]
+        assert len(perf_lines) == 1
+        assert "emotional" in perf_lines[0]
+        assert "keyword" in perf_lines[0]

--- a/tests/test_llm_classifier.py
+++ b/tests/test_llm_classifier.py
@@ -330,6 +330,51 @@ class TestErrorInjection:
         assert result is None
 
 
+class TestTimingInstrumentation:
+    """Tests for response time logging on LLMClassifier."""
+
+    def test_last_call_duration_default_is_zero(self):
+        classifier = LLMClassifier()
+        assert classifier.last_call_duration == 0.0
+
+    def test_last_call_duration_set_after_successful_call(self):
+        classifier = LLMClassifier()
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"response": '{"domain": "logistics"}'}
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        with patch("utils.http_client.get_http_client", return_value=mock_client):
+            classifier._call_ollama("test prompt")
+        assert classifier.last_call_duration > 0.0
+
+    def test_last_call_duration_not_set_on_timeout(self):
+        """Timeout before response should leave last_call_duration at 0."""
+        import httpx
+
+        classifier = LLMClassifier()
+        mock_client = Mock()
+        mock_client.post.side_effect = httpx.TimeoutException("timed out")
+        with patch("utils.http_client.get_http_client", return_value=mock_client):
+            classifier._call_ollama("test prompt")
+        assert classifier.last_call_duration == 0.0
+
+    def test_call_duration_logged_at_info(self):
+        classifier = LLMClassifier()
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"response": '{"domain": "logistics"}'}
+        mock_client = Mock()
+        mock_client.post.return_value = mock_response
+        import logging
+
+        with patch("utils.http_client.get_http_client", return_value=mock_client):
+            with patch.object(logging.getLogger("models.llm_classifier"), "info") as mock_log:
+                classifier._call_ollama("test prompt")
+        logged_messages = [str(call) for call in mock_log.call_args_list]
+        assert any("llm_classifier.call" in msg for msg in logged_messages)
+
+
 # Run tests if executed directly
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `LLMClassifier._call_ollama()` now records `last_call_duration` using `time.perf_counter()` and emits `llm_classifier.call | model=... | duration_s=X.XX` at INFO level
- `OllamaClient.generate()` and `generate_stream()` record `last_generate_duration` with structured log lines for both non-streaming and streaming calls (includes token count and TTFT for streams)
- `ConversationSession._log_perf()` is called after every turn and emits a single consolidated `[PERF]` line: `[PERF] turn=N | classify_s=X.XX | generate_s=X.XX | total_s=X.XX | domain=... | method=...`

## Test plan

- [x] `TestTimingInstrumentation` (4 tests): default value, duration set after successful call, not set on timeout, INFO log contains `llm_classifier.call`
- [x] `TestPerfLogging` (2 tests): `[PERF]` line logged after `process_message()`, line contains domain and method
- [x] Full suite: 941 passed