### PR TITLE
feat: add --list-domains CLI command (closes #100)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -64,11 +64,7 @@ def list_domains():
 
     print("Supported domains:")
     # Sort by risk weight (descending) for better readability
-    sorted_domains = sorted(
-        domains.items(),
-        key=lambda x: x[1].get("risk_weight", 0),
-        reverse=True
-    )
+    sorted_domains = sorted(domains.items(), key=lambda x: x[1].get("risk_weight", 0), reverse=True)
 
     for domain_name, config in sorted_domains:
         risk_weight = config.get("risk_weight", 0)

--- a/src/cli.py
+++ b/src/cli.py
@@ -53,6 +53,30 @@ def run_cli():
     adapter.run()
 
 
+def list_domains():
+    """Print supported domains and their risk weights, then exit."""
+    sys.path.append(str(Path(__file__).parent))
+
+    from utils.scenario_loader import ScenarioLoader
+
+    loader = ScenarioLoader()
+    domains = loader.get_all_domains()
+
+    print("Supported domains:")
+    # Sort by risk weight (descending) for better readability
+    sorted_domains = sorted(
+        domains.items(),
+        key=lambda x: x[1].get("risk_weight", 0),
+        reverse=True
+    )
+
+    for domain_name, config in sorted_domains:
+        risk_weight = config.get("risk_weight", 0)
+        description = config.get("description", "")
+        # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
+        print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
+
+
 def run_maintenance():
     """Run maintenance tasks: prune old data, validate integrity, print summary."""
     sys.path.append(str(Path(__file__).parent))
@@ -131,6 +155,11 @@ def main():
         help="Interface mode: web (Streamlit) or cli (terminal)",
     )
     parser.add_argument(
+        "--list-domains",
+        action="store_true",
+        help="Print supported domains and their risk weights, then exit",
+    )
+    parser.add_argument(
         "--maintenance",
         action="store_true",
         help="Run maintenance tasks (prune data, check integrity) and exit",
@@ -144,7 +173,9 @@ def main():
 
     args = parser.parse_args()
 
-    if args.maintenance:
+    if args.list_domains:
+        list_domains()
+    elif args.maintenance:
         run_maintenance()
     elif args.mode == "cli":
         run_cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Tests for CLI mode."""
+
 from unittest.mock import patch, MagicMock
 
 
@@ -7,6 +8,7 @@ class TestCLIArguments:
         with patch("src.cli.list_domains") as mock_list_domains:
             with patch("sys.argv", ["empathysync", "--list-domains"]):
                 from src.cli import main
+
                 main()
             assert mock_list_domains.called
 
@@ -14,6 +16,7 @@ class TestCLIArguments:
         with patch("src.cli.run_cli") as mock_run_cli:
             with patch("sys.argv", ["empathysync", "--mode", "cli"]):
                 from src.cli import main
+
                 main()
             assert mock_run_cli.called
 
@@ -21,6 +24,7 @@ class TestCLIArguments:
         with patch("src.cli.run_streamlit") as mock_run_streamlit:
             with patch("sys.argv", ["empathysync", "--mode", "web"]):
                 from src.cli import main
+
                 main()
             assert mock_run_streamlit.called
 
@@ -28,6 +32,7 @@ class TestCLIArguments:
         with patch("src.cli.run_streamlit") as mock_run_streamlit:
             with patch("sys.argv", ["empathysync"]):
                 from src.cli import main
+
                 main()
             assert mock_run_streamlit.called
 
@@ -64,16 +69,17 @@ class TestListDomains:
         list_domains()
 
         output = capsys.readouterr().out
-        lines = output.strip().split('\n')
+        lines = output.strip().split("\n")
 
         # Find the domain lines (skip the header)
         domain_lines = [line for line in lines if "risk weight:" in line]
 
         # Extract risk weights from each line
         import re
+
         weights = []
         for line in domain_lines:
-            match = re.search(r'risk weight:\s*([\d.]+)', line)
+            match = re.search(r"risk weight:\s*([\d.]+)", line)
             if match:
                 weights.append(float(match.group(1)))
 
@@ -86,16 +92,19 @@ class TestRunCLI:
         """Test that run_cli actually wires up and calls adapter.run()."""
         mock_adapter_instance = MagicMock()
 
-        with patch("models.ai_wellness_guide.WellnessGuide"), \
-            patch("models.conversation_session.ConversationSession"), \
-            patch("utils.wellness_tracker.WellnessTracker"), \
-            patch("utils.trusted_network.TrustedNetwork"), \
-            patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter:
+        with (
+            patch("models.ai_wellness_guide.WellnessGuide"),
+            patch("models.conversation_session.ConversationSession"),
+            patch("utils.wellness_tracker.WellnessTracker"),
+            patch("utils.trusted_network.TrustedNetwork"),
+            patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter,
+        ):
 
             mock_adapter.return_value = mock_adapter_instance
 
             with patch("sys.argv", ["empathysync", "--mode", "cli"]):
                 from src.cli import main
+
                 main()
 
             mock_adapter_instance.run.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,13 @@ from unittest.mock import patch, MagicMock
 
 
 class TestCLIArguments:
+    def test_list_domains_flag_calls_list_domains(self):
+        with patch("src.cli.list_domains") as mock_list_domains:
+            with patch("sys.argv", ["empathysync", "--list-domains"]):
+                from src.cli import main
+                main()
+            assert mock_list_domains.called
+
     def test_mode_cli_calls_run_cli(self):
         with patch("src.cli.run_cli") as mock_run_cli:
             with patch("sys.argv", ["empathysync", "--mode", "cli"]):
@@ -23,6 +30,55 @@ class TestCLIArguments:
                 from src.cli import main
                 main()
             assert mock_run_streamlit.called
+
+
+class TestListDomains:
+    def test_list_domains_prints_all_domains(self, capsys):
+        """Test that list_domains prints all 8 domains with their risk weights."""
+        from src.cli import list_domains
+
+        list_domains()
+
+        output = capsys.readouterr().out
+
+        # Check that all 8 domains are present
+        assert "crisis" in output
+        assert "harmful" in output
+        assert "health" in output
+        assert "money" in output
+        assert "emotional" in output
+        assert "relationships" in output
+        assert "spirituality" in output
+        assert "logistics" in output
+
+        # Check that risk weights are present
+        assert "risk weight:" in output
+
+        # Check that descriptions are present
+        assert "Suicidal ideation" in output or "Illegal activities" in output
+
+    def test_list_domains_sorted_by_risk_weight(self, capsys):
+        """Test that domains are sorted by risk weight in descending order."""
+        from src.cli import list_domains
+
+        list_domains()
+
+        output = capsys.readouterr().out
+        lines = output.strip().split('\n')
+
+        # Find the domain lines (skip the header)
+        domain_lines = [line for line in lines if "risk weight:" in line]
+
+        # Extract risk weights from each line
+        import re
+        weights = []
+        for line in domain_lines:
+            match = re.search(r'risk weight:\s*([\d.]+)', line)
+            if match:
+                weights.append(float(match.group(1)))
+
+        # Verify that weights are in descending order
+        assert weights == sorted(weights, reverse=True)
 
 
 class TestRunCLI:


### PR DESCRIPTION
Picks up #102 from @jlaportebot with black formatting applied.

## Summary

- `empathysync --list-domains` prints all 8 domains sorted by risk weight descending and exits
- Does not start Streamlit or require Ollama
- 3 new tests: flag routing, all 8 domains present, sort order verified

## Changes

- `src/cli.py`: list_domains() function + --list-domains argparse argument
- `tests/test_cli.py`: TestListDomains class (2 tests) + flag routing test

## Test plan

- [x] 7 CLI tests pass
- [x] Black formatting clean