### PR TITLE
Release v1.10.1: documentation accuracy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to empathySync are documented here.
 
+## v1.10.1 (2026-06-01) - Documentation Accuracy
+
+**"The docs should say what the code does."**
+
+Documentation-only patch. No code changes.
+
+### Fixed
+- Corrected stale tunables in documentation to match the configured defaults in `scenarios/config/system_defaults.yaml`: daily-usage cooldown is **180 minutes** (docs said 120), identity reminders fire **every 9 turns** (docs said 6), and practical mode allows up to **5000 tokens** (docs said 2000). Affected `docs/architecture.md`, `docs/usage.md`, and `CLAUDE.md`
+
+---
+
 ## v1.10.0 (2026-06-01) - Connection Steering & CLI
 
 **"Noticing people. Not making it a topic."**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ empathySync/
   - `logistics` domain: writing requests, coding, explanations, general questions
   - `is_practical_technique: true` in any domain (Phase 9.1): "How do I meditate?", "What are budgeting methods?"
 - Behavior: Full assistant capability
-  - No word limits (up to 2000 tokens)
+  - No word limits (up to 5000 tokens)
   - Markdown formatting, code blocks, lists allowed
   - Complete the task thoroughly
   - No identity reminders or therapeutic framing
@@ -195,7 +195,7 @@ empathySync/
   - Word limits enforced (50-150 words)
   - Plain prose, no formatting
   - Redirects to human support
-  - Identity reminders every 6 turns
+  - Identity reminders every 9 turns
 
 **Phase 9.1: Practical Technique Detection**
 The LLM classifier distinguishes between:
@@ -226,7 +226,7 @@ The LLM classifier distinguishes between:
    - `spirituality`: 10 turns
    - `crisis/harmful`: 1 turn
 8. **Dependency Intervention**: Graduated responses if dependency score exceeds thresholds
-9. **Identity Reminder**: Injected every 6 turns (only in Reflective Mode)
+9. **Identity Reminder**: Injected every 9 turns (only in Reflective Mode)
 10. System prompt composed (base + style + mode-specific rules + post-crisis context if applicable), Ollama called locally
 11. **Response streams** in real-time via `generate_response_stream()` (tokens yielded as generated)
 12. Response safety-checked via `_contains_harmful_content()` before/during display
@@ -359,7 +359,7 @@ When another device holds the lock (`ENABLE_DEVICE_LOCK=true`), all write operat
 
 `WellnessTracker.should_enforce_cooldown()` returns true when:
 - 7+ sessions today
-- 120+ minutes today
+- 180+ minutes today
 - Dependency score >= 8
 
 ### Key Design Constraints (from MANIFESTO.md)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 *Most chatbots want you to keep talking.*
 *This one wants you to leave and go live your life.*
 
-[![v1.10.0](https://img.shields.io/badge/release-v1.10.0-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.10.0)
+[![v1.10.1](https://img.shields.io/badge/release-v1.10.1-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.10.1)
 [![CI](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml/badge.svg)](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Local-First](https://img.shields.io/badge/Privacy-Local--First-blue.svg)](#)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ User Input
 │  2. COOLDOWN CHECK                          │
 │     WellnessTracker.should_enforce_cooldown │
 │     - 7+ sessions today? → Block            │
-│     - 120+ minutes today? → Block           │
+│     - 180+ minutes today? → Block           │
 │     - Dependency score ≥8? → Block          │
 └─────────────────────────────────────────────┘
     │ Pass
@@ -154,7 +154,7 @@ User Input
     ▼
 ┌─────────────────────────────────────────────┐
 │  8. IDENTITY REMINDER (Reflective only)     │
-│     Every 6 turns: "I'm software,           │
+│     Every 9 turns: "I'm software,           │
 │     not a person..."                        │
 └─────────────────────────────────────────────┘
     │
@@ -303,7 +303,7 @@ Response to User (streamed in real-time)
 │                                                                 │
 │   Behavior:                                                     │
 │   ┌─────────────────────────────────────────────────────────┐   │
-│   │ ✓ Full response length (up to 2000 tokens)              │   │
+│   │ ✓ Full response length (up to 5000 tokens)              │   │
 │   │ ✓ Markdown formatting allowed                           │   │
 │   │ ✓ Code blocks, lists, headers                           │   │
 │   │ ✓ No identity reminders                                 │   │
@@ -332,7 +332,7 @@ Response to User (streamed in real-time)
 │   │ ✗ Word limits enforced (50-150 words)                   │   │
 │   │ ✗ Plain prose only, no formatting                       │   │
 │   │ ✓ Redirects to human support                            │   │
-│   │ ✓ Identity reminders every 6 turns                      │   │
+│   │ ✓ Identity reminders every 9 turns                      │   │
 │   │ ✓ Brief, restrained responses                           │   │
 │   └─────────────────────────────────────────────────────────┘   │
 │                                                                 │

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,7 +174,7 @@ This transparency is intentional -you should always know when the system is limi
 
 The system may block new sessions if:
 - You've had 7+ sessions today
-- You've spent 120+ minutes today
+- You've spent 180+ minutes today
 - Your dependency score is high
 
 This isn't punishment -it's the system doing its job of not becoming a crutch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "empathysync"
-version = "1.10.0"
+version = "1.10.1"
 description = "A local-first AI assistant that provides full help for practical tasks while applying restraint on sensitive topics"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Documentation-only patch. No code changes.

Corrects stale tunables in the docs to match the configured defaults in `scenarios/config/system_defaults.yaml`:
- daily-usage cooldown: 120 -> **180 minutes**
- identity reminders: every 6 -> **every 9 turns**
- practical mode token limit: 2000 -> **5000 tokens**

Touches `docs/architecture.md`, `docs/usage.md`, `CLAUDE.md`, plus version bump (pyproject), CHANGELOG and README badge for the v1.10.1 release.