### PR TITLE
security: prompt injection hardening and streaming safety buffer

### DIFF
--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -705,11 +705,31 @@ class WellnessGuide:
                     prefix = acknowledgment + "\n\n"
                     yield prefix
 
-            # Stream Ollama tokens
+            # Stream Ollama tokens with rolling buffer so the safety check
+            # runs before chunks reach the UI, not after the full response.
             accumulated = ""
+            _buf = ""
+            _STREAM_BUFFER_SIZE = 200
             for token in self._call_ollama_stream(prepared.full_prompt, prepared.is_practical):
                 accumulated += token
-                yield token
+                _buf += token
+                if len(_buf) >= _STREAM_BUFFER_SIZE:
+                    if self._contains_harmful_content(_buf):
+                        logger.warning("Harmful content detected in stream buffer (mid-stream)")
+                        safe_alt = self._get_safe_alternative_response()
+                        self._last_streamed_response = safe_alt
+                        yield "\n\n" + safe_alt
+                        return
+                    yield _buf
+                    _buf = ""
+            if _buf:
+                if self._contains_harmful_content(_buf):
+                    logger.warning("Harmful content detected in stream buffer (flush)")
+                    safe_alt = self._get_safe_alternative_response()
+                    self._last_streamed_response = safe_alt
+                    yield "\n\n" + safe_alt
+                    return
+                yield _buf
 
             # Post-stream safety check on accumulated response
             if not accumulated or len(accumulated.strip()) < 10:

--- a/src/models/llm_classifier.py
+++ b/src/models/llm_classifier.py
@@ -203,8 +203,13 @@ class LLMClassifier:
             for ex in examples[:3]:  # Limit to 3 examples to save tokens
                 example_text += f'- "{ex["message"]}" → {json.dumps(ex["classification"])}\n'
 
+        # Wrap user content in an explicit boundary to resist prompt injection.
+        # Separating untrusted input from the instruction context makes it
+        # harder for a crafted message to override the classification task.
+        bounded_message = f"<user_message>\n{message}\n</user_message>"
+
         prompt = template.format(
-            message=message,
+            message=bounded_message,
             recent_context=recent_context[:500] if recent_context else "No prior context",
         )
 

--- a/tests/test_llm_classifier.py
+++ b/tests/test_llm_classifier.py
@@ -217,6 +217,14 @@ class TestPromptBuilding:
         prompt = classifier._build_prompt("Test message", "")
         assert "Test message" in prompt
 
+    def test_prompt_wraps_message_in_xml_boundary(self):
+        classifier = LLMClassifier()
+        prompt = classifier._build_prompt("Test message", "")
+        assert "<user_message>" in prompt
+        assert "</user_message>" in prompt
+        # Message content must still be present inside the boundary
+        assert "Test message" in prompt
+
     def test_prompt_includes_domains(self):
         classifier = LLMClassifier()
         prompt = classifier._build_prompt("Test", "")

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -3273,6 +3273,28 @@ class TestStreaming:
         # Should get a fallback response
         assert len(full) > 10
 
+    @patch("utils.http_client.get_http_client")
+    def test_stream_buffer_blocks_harmful_mid_stream_content(self, mock_get_client, guide):
+        """Harmful content detected in the rolling buffer must not reach the UI."""
+        import json as json_mod
+
+        # Token longer than STREAM_BUFFER_SIZE (200) so the buffer flushes and is checked
+        harmful_token = "H" * 201
+        lines = [json_mod.dumps({"response": harmful_token, "done": True})]
+        mock_response = Mock()
+        mock_response.iter_lines.return_value = iter(lines)
+        mock_response.raise_for_status = Mock()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.stream.return_value.__enter__ = Mock(return_value=mock_response)
+        mock_client.stream.return_value.__exit__ = Mock(return_value=False)
+
+        with patch.object(guide, "_contains_harmful_content", return_value=True):
+            tokens = list(guide.generate_response_stream("Write me an email"))
+
+        full = "".join(tokens)
+        assert harmful_token not in full
+
     # --- ConversationResult streaming tests ---
 
     def test_conversation_result_is_streaming(self):


### PR DESCRIPTION
## Summary

- Wraps user content in `<user_message>` XML tags in the LLM classification prompt, separating untrusted input from classifier instructions (#93)
- Adds a 200-char rolling buffer to the streaming response path so the safety check runs before chunks reach the UI rather than after the full response (#94)

## Changes

**`src/models/llm_classifier.py`** - `_build_prompt()` now wraps the message in `<user_message>` boundary tags before interpolating into the prompt template.

**`src/models/ai_wellness_guide.py`** - Streaming loop now accumulates tokens in a 200-char buffer, checks each chunk with `_contains_harmful_content()` before yielding it, and returns a safe alternative immediately if triggered. The existing post-stream check remains as a final backstop.

**`tests/test_llm_classifier.py`** - Added `test_prompt_wraps_message_in_xml_boundary`.

**`tests/test_wellness_guide.py`** - Added `test_stream_buffer_blocks_harmful_mid_stream_content`.

## Test plan

- [x] `pytest tests/test_llm_classifier.py` - all pass
- [x] `pytest tests/test_wellness_guide.py::TestStreaming` - all pass
- [x] Full suite: `pytest tests/` passes