### PR TITLE
feat: add --log-level CLI flag

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -11,6 +11,7 @@ Usage:
 
 import sys
 import argparse
+import logging
 import subprocess
 from pathlib import Path
 
@@ -166,8 +167,17 @@ def main():
         version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
         help="Show the application version and exit",
     )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default=None,
+        help="Set log verbosity (overrides LOG_LEVEL env var)",
+    )
 
     args = parser.parse_args()
+
+    if args.log_level:
+        logging.getLogger().setLevel(args.log_level)
 
     if args.list_domains:
         list_domains()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI mode."""
 
+import logging
 from unittest.mock import patch, MagicMock
 
 
@@ -35,6 +36,59 @@ class TestCLIArguments:
 
                 main()
             assert mock_run_streamlit.called
+
+    def test_log_level_debug_sets_root_logger(self):
+        """--log-level DEBUG overrides the root logger level."""
+        root = logging.getLogger()
+        original = root.level
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
+                    from src.cli import main
+
+                    main()
+            assert root.level == logging.DEBUG
+        finally:
+            root.setLevel(original)
+
+    def test_log_level_warning_sets_root_logger(self):
+        """--log-level WARNING overrides the root logger level."""
+        root = logging.getLogger()
+        original = root.level
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
+                    from src.cli import main
+
+                    main()
+            assert root.level == logging.WARNING
+        finally:
+            root.setLevel(original)
+
+    def test_log_level_absent_does_not_modify_root_logger(self):
+        """When --log-level is omitted, root logger level is left untouched."""
+        root = logging.getLogger()
+        root.setLevel(logging.ERROR)
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync"]):
+                    from src.cli import main
+
+                    main()
+            assert root.level == logging.ERROR
+        finally:
+            root.setLevel(logging.WARNING)
+
+    def test_log_level_invalid_choice_exits_nonzero(self):
+        """An unrecognised --log-level value causes argparse to exit non-zero."""
+        import pytest
+
+        with patch("sys.argv", ["empathysync", "--log-level", "VERBOSE"]):
+            from src.cli import main
+
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code != 0
 
 
 class TestListDomains:


### PR DESCRIPTION
## Summary

- Adds `--log-level` flag to the CLI so users can set log verbosity inline without touching `LOG_LEVEL` in `.env` (#99)

## Usage

```bash
empathysync --log-level DEBUG
empathysync --mode cli --log-level WARNING
empathysync --log-level ERROR
```

When omitted, behaviour is unchanged - the root logger level is not touched.

## Changes

**`src/cli.py`** - Added `import logging`, new `--log-level` argument with choices `DEBUG/INFO/WARNING/ERROR`, and a `getLogger().setLevel()` call immediately after parsing.

**`tests/test_cli.py`** - Added four tests to the existing `TestCLIArguments` class covering DEBUG/WARNING overrides, absent flag, and invalid choice.

## Test plan

- [ ] `pytest tests/test_cli.py` - all pass
- [ ] `empathysync --log-level DEBUG` logs at DEBUG level
- [ ] `empathysync --log-level VERBOSE` exits non-zero with usage error