### PR TITLE
docs: add missing CLI flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ empathysync                # Launches Streamlit web UI
 empathysync --mode cli     # Direct terminal mode
 empathysync --version      # Show version and exit
 empathysync --list-domains # List all supported classification domains
+empathysync --maintenance  # Prune old data, check integrity, and exit
+empathysync --log-level DEBUG  # Set log verbosity (DEBUG, INFO, WARNING, ERROR)
 ```
 
 ### Requirements


### PR DESCRIPTION
## Summary

Add the two documented CLI flags that were missing from the pip-install usage block in the README.

## Changes

- add `empathysync --maintenance` to the README CLI examples
- add `empathysync --log-level DEBUG` to the README CLI examples
- keep descriptions aligned with the existing concise command list style

## Related Issues

Closes #109

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [x] Manually tested (if applicable)
- [ ] New tests added for new functionality (if applicable)

Manual verification for this docs-only change:
- confirmed both flags exist in `src/cli.py`
- ran `git diff --check`
- `python3 -m src.cli --help` could not run in this environment because `python-dotenv` is not installed in the fresh clone

## Screenshots

Not applicable.
