### PR TITLE
feat: add --json flag to --list-domains output

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -3,11 +3,11 @@ CLI entry point for empathySync.
 
 Usage:
     empathysync              # Launches Streamlit web interface (default)
-        empathysync --mode web   # Same as above
-            empathysync --mode cli   # Direct terminal interface (no browser needed)
-                empathysync --maintenance  # Run maintenance tasks and exit
-                    empathysync --version    # Print version and exit
-                    """
+    empathysync --mode web   # Same as above
+    empathysync --mode cli   # Direct terminal interface (no browser needed)
+    empathysync --maintenance  # Run maintenance tasks and exit
+    empathysync --version    # Print version and exit
+"""
 
 import sys
 import json
@@ -17,30 +17,28 @@ import subprocess
 from pathlib import Path
 
 
-
 def run_streamlit():
-        """Launch empathySync Streamlit app."""
-        app_path = Path(__file__).parent / "app.py"
-        sys.exit(
-            subprocess.call(
-                [
-                    sys.executable,
-                    "-m",
-                    "streamlit",
-                    "run",
-                    str(app_path),
-                    "--server.headless",
-                    "true",
-                ]
-            )
+    """Launch empathySync Streamlit app."""
+    app_path = Path(__file__).parent / "app.py"
+    sys.exit(
+        subprocess.call(
+            [
+                sys.executable,
+                "-m",
+                "streamlit",
+                "run",
+                str(app_path),
+                "--server.headless",
+                "true",
+            ]
         )
-
+    )
 
 
 def run_cli():
-        """Launch empathySync in direct terminal mode."""
-        # Add src to path for imports (same as app.py)
-        sys.path.append(str(Path(__file__).parent))
+    """Launch empathySync in direct terminal mode."""
+    # Add src to path for imports (same as app.py)
+    sys.path.append(str(Path(__file__).parent))
 
     from models.ai_wellness_guide import WellnessGuide
     from models.conversation_session import ConversationSession
@@ -58,8 +56,8 @@ def run_cli():
 
 
 def list_domains(json_output=False):
-        """Print supported domains and their risk weights, then exit."""
-        sys.path.append(str(Path(__file__).parent))
+    """Print supported domains and their risk weights, then exit."""
+    sys.path.append(str(Path(__file__).parent))
 
     from utils.scenario_loader import ScenarioLoader
 
@@ -70,27 +68,27 @@ def list_domains(json_output=False):
     sorted_domains = sorted(domains.items(), key=lambda x: x[1].get("risk_weight", 0), reverse=True)
 
     if json_output:
-                output = [
-                                {
-                                                    "domain": domain_name,
-                                                    "risk_weight": config.get("risk_weight", 0),
-                                                    "description": config.get("description", ""),
-                                }
-                                for domain_name, config in sorted_domains
-                ]
-                print(json.dumps(output, indent=2))
-else:
-            print("Supported domains:")
-            for domain_name, config in sorted_domains:
-                            risk_weight = config.get("risk_weight", 0)
-                            description = config.get("description", "")
-                            # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
-                            print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
+        output = [
+            {
+                "domain": domain_name,
+                "risk_weight": config.get("risk_weight", 0),
+                "description": config.get("description", ""),
+            }
+            for domain_name, config in sorted_domains
+        ]
+        print(json.dumps(output, indent=2))
+    else:
+        print("Supported domains:")
+        for domain_name, config in sorted_domains:
+            risk_weight = config.get("risk_weight", 0)
+            description = config.get("description", "")
+            # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
+            print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
 
 
 def run_maintenance():
-        """Run maintenance tasks: prune old data, validate integrity, print summary."""
-        sys.path.append(str(Path(__file__).parent))
+    """Run maintenance tasks: prune old data, validate integrity, print summary."""
+    sys.path.append(str(Path(__file__).parent))
 
     from config.settings import settings
     from utils.storage_backend import get_storage_backend
@@ -102,47 +100,48 @@ def run_maintenance():
     # 1. Data pruning
     retention = settings.DATA_RETENTION_DAYS
     if retention > 0:
-                print(f"\nPruning records older than {retention} days...")
-                try:
-                                backend = get_storage_backend()
-                                pruned = backend.prune_old_data(retention)
-                                if pruned > 0:
-                                                    print(f"  Removed {pruned} old records")
-                else:
-                                    print("  No records to prune")
-except Exception as e:
+        print(f"\nPruning records older than {retention} days...")
+        try:
+            backend = get_storage_backend()
+            pruned = backend.prune_old_data(retention)
+            if pruned > 0:
+                print(f"  Removed {pruned} old records")
+            else:
+                print("  No records to prune")
+        except Exception as e:
             print(f"  Pruning failed: {e}")
-else:
+    else:
         print("\nData pruning disabled (DATA_RETENTION_DAYS=0)")
 
     # 2. Dependency score check
-        print("\nChecking dependency patterns...")
-        try:
-                    tracker = WellnessTracker()
-                    signals = tracker.calculate_dependency_signals()
-                    score = signals.get("dependency_score", 0)
-                    sessions_week = signals.get("sessions_week", 0)
-                    print(f"  Sessions this week: {sessions_week}")
-                    print(f"  Dependency score: {score:.1f}/10")
-                    if score >= 6:
-                                    print("  Warning: elevated dependency pattern detected")
-elif score <= 2:
+    print("\nChecking dependency patterns...")
+    try:
+        tracker = WellnessTracker()
+        signals = tracker.calculate_dependency_signals()
+        score = signals.get("dependency_score", 0)
+        sessions_week = signals.get("sessions_week", 0)
+        print(f"  Sessions this week: {sessions_week}")
+        print(f"  Dependency score: {score:.1f}/10")
+        if score >= 6:
+            print("  Warning: elevated dependency pattern detected")
+        elif score <= 2:
             print("  Healthy usage pattern")
-except Exception as e:
+    except Exception as e:
         print(f"  Dependency check failed: {e}")
 
     # 3. Data integrity
     print("\nValidating data integrity...")
     try:
-                backend = get_storage_backend()
-                # Quick read test - if data is corrupt, this raises
-                backend.get_recent_sessions(limit=1)
-                print("  Data integrity OK")
-except Exception as e:
-            print(f"  Integrity check failed: {e}")
+        backend = get_storage_backend()
+        # Quick read test - if data is corrupt, this will raise
+        backend.get_recent_check_ins(days=1)
+        backend.get_recent_policy_events(limit=1)
+        print("  Data files OK")
+    except Exception as e:
+        print(f"  Data integrity issue: {e}")
 
     # 4. Configuration summary
-        print("\nConfiguration:")
+    print("\nConfiguration:")
     print(f"  Model: {settings.OLLAMA_MODEL or '(not set)'}")
     print(f"  Host: {settings.OLLAMA_HOST or '(not set)'}")
     print(f"  Storage: {'SQLite' if settings.USE_SQLITE else 'JSON'}")
@@ -153,60 +152,60 @@ except Exception as e:
 
 
 def main():
-        """Main entry point with mode selection."""
-        sys.path.append(str(Path(__file__).parent))
-        from config.settings import settings
+    """Main entry point with mode selection."""
+    sys.path.append(str(Path(__file__).parent))
+    from config.settings import settings
 
     parser = argparse.ArgumentParser(description="empathySync - Help that knows when to stop")
     parser.add_argument(
-                "--mode",
-                choices=["web", "cli"],
-                default="web",
-                help="Interface mode: web (Streamlit) or cli (terminal)",
+        "--mode",
+        choices=["web", "cli"],
+        default="web",
+        help="Interface mode: web (Streamlit) or cli (terminal)",
     )
     parser.add_argument(
-                "--list-domains",
-                action="store_true",
-                help="Print supported domains and their risk weights, then exit",
+        "--list-domains",
+        action="store_true",
+        help="Print supported domains and their risk weights, then exit",
     )
     parser.add_argument(
-                "--json",
-                action="store_true",
-                default=False,
-                help="Output --list-domains as JSON instead of plain text",
+        "--json",
+        action="store_true",
+        default=False,
+        help="Output --list-domains as JSON instead of plain text",
     )
     parser.add_argument(
-                "--maintenance",
-                action="store_true",
-                help="Run maintenance tasks (prune data, check integrity) and exit",
+        "--maintenance",
+        action="store_true",
+        help="Run maintenance tasks (prune data, check integrity) and exit",
     )
     parser.add_argument(
-                "--version",
-                action="version",
-                version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
-                help="Show the application version and exit",
+        "--version",
+        action="version",
+        version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
+        help="Show the application version and exit",
     )
     parser.add_argument(
-                "--log-level",
-                choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-                default=None,
-                help="Set log verbosity (overrides LOG_LEVEL env var)",
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default=None,
+        help="Set log verbosity (overrides LOG_LEVEL env var)",
     )
 
     args = parser.parse_args()
 
     if args.log_level:
-                logging.getLogger().setLevel(args.log_level)
+        logging.getLogger().setLevel(args.log_level)
 
     if args.list_domains:
-                list_domains(json_output=args.json)
-elif args.maintenance:
-            run_maintenance()
-elif args.mode == "cli":
-            run_cli()
-else:
-            run_streamlit()
+        list_domains(json_output=args.json)
+    elif args.maintenance:
+        run_maintenance()
+    elif args.mode == "cli":
+        run_cli()
+    else:
+        run_streamlit()
 
 
 if __name__ == "__main__":
-        main()
+    main()

--- a/src/cli.py
+++ b/src/cli.py
@@ -3,41 +3,44 @@ CLI entry point for empathySync.
 
 Usage:
     empathysync              # Launches Streamlit web interface (default)
-    empathysync --mode web   # Same as above
-    empathysync --mode cli   # Direct terminal interface (no browser needed)
-    empathysync --maintenance  # Run maintenance tasks and exit
-    empathysync --version    # Print version and exit
-"""
+        empathysync --mode web   # Same as above
+            empathysync --mode cli   # Direct terminal interface (no browser needed)
+                empathysync --maintenance  # Run maintenance tasks and exit
+                    empathysync --version    # Print version and exit
+                    """
 
 import sys
+import json
 import argparse
 import logging
 import subprocess
 from pathlib import Path
 
 
+
 def run_streamlit():
-    """Launch empathySync Streamlit app."""
-    app_path = Path(__file__).parent / "app.py"
-    sys.exit(
-        subprocess.call(
-            [
-                sys.executable,
-                "-m",
-                "streamlit",
-                "run",
-                str(app_path),
-                "--server.headless",
-                "true",
-            ]
+        """Launch empathySync Streamlit app."""
+        app_path = Path(__file__).parent / "app.py"
+        sys.exit(
+            subprocess.call(
+                [
+                    sys.executable,
+                    "-m",
+                    "streamlit",
+                    "run",
+                    str(app_path),
+                    "--server.headless",
+                    "true",
+                ]
+            )
         )
-    )
+
 
 
 def run_cli():
-    """Launch empathySync in direct terminal mode."""
-    # Add src to path for imports (same as app.py)
-    sys.path.append(str(Path(__file__).parent))
+        """Launch empathySync in direct terminal mode."""
+        # Add src to path for imports (same as app.py)
+        sys.path.append(str(Path(__file__).parent))
 
     from models.ai_wellness_guide import WellnessGuide
     from models.conversation_session import ConversationSession
@@ -54,29 +57,40 @@ def run_cli():
     adapter.run()
 
 
-def list_domains():
-    """Print supported domains and their risk weights, then exit."""
-    sys.path.append(str(Path(__file__).parent))
+def list_domains(json_output=False):
+        """Print supported domains and their risk weights, then exit."""
+        sys.path.append(str(Path(__file__).parent))
 
     from utils.scenario_loader import ScenarioLoader
 
     loader = ScenarioLoader()
     domains = loader.get_all_domains()
 
-    print("Supported domains:")
     # Sort by risk weight (descending) for better readability
     sorted_domains = sorted(domains.items(), key=lambda x: x[1].get("risk_weight", 0), reverse=True)
 
-    for domain_name, config in sorted_domains:
-        risk_weight = config.get("risk_weight", 0)
-        description = config.get("description", "")
-        # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
-        print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
+    if json_output:
+                output = [
+                                {
+                                                    "domain": domain_name,
+                                                    "risk_weight": config.get("risk_weight", 0),
+                                                    "description": config.get("description", ""),
+                                }
+                                for domain_name, config in sorted_domains
+                ]
+                print(json.dumps(output, indent=2))
+else:
+            print("Supported domains:")
+            for domain_name, config in sorted_domains:
+                            risk_weight = config.get("risk_weight", 0)
+                            description = config.get("description", "")
+                            # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
+                            print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
 
 
 def run_maintenance():
-    """Run maintenance tasks: prune old data, validate integrity, print summary."""
-    sys.path.append(str(Path(__file__).parent))
+        """Run maintenance tasks: prune old data, validate integrity, print summary."""
+        sys.path.append(str(Path(__file__).parent))
 
     from config.settings import settings
     from utils.storage_backend import get_storage_backend
@@ -88,48 +102,47 @@ def run_maintenance():
     # 1. Data pruning
     retention = settings.DATA_RETENTION_DAYS
     if retention > 0:
-        print(f"\nPruning records older than {retention} days...")
-        try:
-            backend = get_storage_backend()
-            pruned = backend.prune_old_data(retention)
-            if pruned > 0:
-                print(f"  Removed {pruned} old records")
-            else:
-                print("  No records to prune")
-        except Exception as e:
+                print(f"\nPruning records older than {retention} days...")
+                try:
+                                backend = get_storage_backend()
+                                pruned = backend.prune_old_data(retention)
+                                if pruned > 0:
+                                                    print(f"  Removed {pruned} old records")
+                else:
+                                    print("  No records to prune")
+except Exception as e:
             print(f"  Pruning failed: {e}")
-    else:
+else:
         print("\nData pruning disabled (DATA_RETENTION_DAYS=0)")
 
     # 2. Dependency score check
-    print("\nChecking dependency patterns...")
-    try:
-        tracker = WellnessTracker()
-        signals = tracker.calculate_dependency_signals()
-        score = signals.get("dependency_score", 0)
-        sessions_week = signals.get("sessions_week", 0)
-        print(f"  Sessions this week: {sessions_week}")
-        print(f"  Dependency score: {score:.1f}/10")
-        if score >= 6:
-            print("  Warning: elevated dependency pattern detected")
-        elif score <= 2:
+        print("\nChecking dependency patterns...")
+        try:
+                    tracker = WellnessTracker()
+                    signals = tracker.calculate_dependency_signals()
+                    score = signals.get("dependency_score", 0)
+                    sessions_week = signals.get("sessions_week", 0)
+                    print(f"  Sessions this week: {sessions_week}")
+                    print(f"  Dependency score: {score:.1f}/10")
+                    if score >= 6:
+                                    print("  Warning: elevated dependency pattern detected")
+elif score <= 2:
             print("  Healthy usage pattern")
-    except Exception as e:
+except Exception as e:
         print(f"  Dependency check failed: {e}")
 
     # 3. Data integrity
     print("\nValidating data integrity...")
     try:
-        backend = get_storage_backend()
-        # Quick read test - if data is corrupt, this will raise
-        backend.get_recent_check_ins(days=1)
-        backend.get_recent_policy_events(limit=1)
-        print("  Data files OK")
-    except Exception as e:
-        print(f"  Data integrity issue: {e}")
+                backend = get_storage_backend()
+                # Quick read test - if data is corrupt, this raises
+                backend.get_recent_sessions(limit=1)
+                print("  Data integrity OK")
+except Exception as e:
+            print(f"  Integrity check failed: {e}")
 
     # 4. Configuration summary
-    print("\nConfiguration:")
+        print("\nConfiguration:")
     print(f"  Model: {settings.OLLAMA_MODEL or '(not set)'}")
     print(f"  Host: {settings.OLLAMA_HOST or '(not set)'}")
     print(f"  Storage: {'SQLite' if settings.USE_SQLITE else 'JSON'}")
@@ -140,54 +153,60 @@ def run_maintenance():
 
 
 def main():
-    """Main entry point with mode selection."""
-    sys.path.append(str(Path(__file__).parent))
-    from config.settings import settings
+        """Main entry point with mode selection."""
+        sys.path.append(str(Path(__file__).parent))
+        from config.settings import settings
 
     parser = argparse.ArgumentParser(description="empathySync - Help that knows when to stop")
     parser.add_argument(
-        "--mode",
-        choices=["web", "cli"],
-        default="web",
-        help="Interface mode: web (Streamlit) or cli (terminal)",
+                "--mode",
+                choices=["web", "cli"],
+                default="web",
+                help="Interface mode: web (Streamlit) or cli (terminal)",
     )
     parser.add_argument(
-        "--list-domains",
-        action="store_true",
-        help="Print supported domains and their risk weights, then exit",
+                "--list-domains",
+                action="store_true",
+                help="Print supported domains and their risk weights, then exit",
     )
     parser.add_argument(
-        "--maintenance",
-        action="store_true",
-        help="Run maintenance tasks (prune data, check integrity) and exit",
+                "--json",
+                action="store_true",
+                default=False,
+                help="Output --list-domains as JSON instead of plain text",
     )
     parser.add_argument(
-        "--version",
-        action="version",
-        version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
-        help="Show the application version and exit",
+                "--maintenance",
+                action="store_true",
+                help="Run maintenance tasks (prune data, check integrity) and exit",
     )
     parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default=None,
-        help="Set log verbosity (overrides LOG_LEVEL env var)",
+                "--version",
+                action="version",
+                version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
+                help="Show the application version and exit",
+    )
+    parser.add_argument(
+                "--log-level",
+                choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+                default=None,
+                help="Set log verbosity (overrides LOG_LEVEL env var)",
     )
 
     args = parser.parse_args()
 
     if args.log_level:
-        logging.getLogger().setLevel(args.log_level)
+                logging.getLogger().setLevel(args.log_level)
 
     if args.list_domains:
-        list_domains()
-    elif args.maintenance:
-        run_maintenance()
-    elif args.mode == "cli":
-        run_cli()
-    else:
-        run_streamlit()
+                list_domains(json_output=args.json)
+elif args.maintenance:
+            run_maintenance()
+elif args.mode == "cli":
+            run_cli()
+else:
+            run_streamlit()
 
 
 if __name__ == "__main__":
-    main()
+        main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,95 +6,95 @@ from unittest.mock import patch, MagicMock
 
 
 class TestCLIArguments:
-        def test_list_domains_flag_calls_list_domains(self):
-                    with patch("src.cli.list_domains") as mock_list_domains:
-                                    with patch("sys.argv", ["empathysync", "--list-domains"]):
-                                                        from src.cli import main
+    def test_list_domains_flag_calls_list_domains(self):
+        with patch("src.cli.list_domains") as mock_list_domains:
+            with patch("sys.argv", ["empathysync", "--list-domains"]):
+                from src.cli import main
 
-                                        main()
-                                    assert mock_list_domains.called
+                main()
+            assert mock_list_domains.called
 
-                def test_mode_cli_calls_run_cli(self):
-                            with patch("src.cli.run_cli") as mock_run_cli:
-                                            with patch("sys.argv", ["empathysync", "--mode", "cli"]):
-                                                                from src.cli import main
+    def test_mode_cli_calls_run_cli(self):
+        with patch("src.cli.run_cli") as mock_run_cli:
+            with patch("sys.argv", ["empathysync", "--mode", "cli"]):
+                from src.cli import main
 
-                                                main()
-                                            assert mock_run_cli.called
+                main()
+            assert mock_run_cli.called
 
-                        def test_mode_web_calls_run_streamlit(self):
-                                    with patch("src.cli.run_streamlit") as mock_run_streamlit:
-                                                    with patch("sys.argv", ["empathysync", "--mode", "web"]):
-                                                                        from src.cli import main
+    def test_mode_web_calls_run_streamlit(self):
+        with patch("src.cli.run_streamlit") as mock_run_streamlit:
+            with patch("sys.argv", ["empathysync", "--mode", "web"]):
+                from src.cli import main
 
-                                                        main()
-                                                    assert mock_run_streamlit.called
+                main()
+            assert mock_run_streamlit.called
 
-                                def test_default_mode_calls_run_streamlit(self):
-                                            with patch("src.cli.run_streamlit") as mock_run_streamlit:
-                                                            with patch("sys.argv", ["empathysync"]):
-                                                                                from src.cli import main
+    def test_default_mode_calls_run_streamlit(self):
+        with patch("src.cli.run_streamlit") as mock_run_streamlit:
+            with patch("sys.argv", ["empathysync"]):
+                from src.cli import main
 
-                                                                main()
-                                                            assert mock_run_streamlit.called
+                main()
+            assert mock_run_streamlit.called
 
-                                        def test_log_level_debug_sets_root_logger(self):
-                                                    """--log-level DEBUG overrides the root logger level."""
-                                                    root = logging.getLogger()
-                                                    original = root.level
-                                                    try:
-                                                                    with patch("src.cli.run_streamlit"):
-                                                                                        with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
-                                                                                                                from src.cli import main
+    def test_log_level_debug_sets_root_logger(self):
+        """--log-level DEBUG overrides the root logger level."""
+        root = logging.getLogger()
+        original = root.level
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
+                    from src.cli import main
 
-                                                                                            main()
-                                                                                    assert root.level == logging.DEBUG
-finally:
+                    main()
+            assert root.level == logging.DEBUG
+        finally:
             root.setLevel(original)
 
     def test_log_level_warning_sets_root_logger(self):
-                """--log-level WARNING overrides the root logger level."""
-                root = logging.getLogger()
-                original = root.level
-                try:
-                                with patch("src.cli.run_streamlit"):
-                                                    with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
-                                                                            from src.cli import main
+        """--log-level WARNING overrides the root logger level."""
+        root = logging.getLogger()
+        original = root.level
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
+                    from src.cli import main
 
-                                                        main()
-                                                assert root.level == logging.WARNING
-finally:
+                    main()
+            assert root.level == logging.WARNING
+        finally:
             root.setLevel(original)
 
     def test_log_level_absent_does_not_modify_root_logger(self):
-                """When --log-level is omitted, root logger level is left untouched."""
-                root = logging.getLogger()
-                root.setLevel(logging.ERROR)
-                try:
-                                with patch("src.cli.run_streamlit"):
-                                                    with patch("sys.argv", ["empathysync"]):
-                                                                            from src.cli import main
+        """When --log-level is omitted, root logger level is left untouched."""
+        root = logging.getLogger()
+        root.setLevel(logging.ERROR)
+        try:
+            with patch("src.cli.run_streamlit"):
+                with patch("sys.argv", ["empathysync"]):
+                    from src.cli import main
 
-                                                        main()
-                                                assert root.level == logging.ERROR
-finally:
+                    main()
+            assert root.level == logging.ERROR
+        finally:
             root.setLevel(logging.WARNING)
 
     def test_log_level_invalid_choice_exits_nonzero(self):
-                """An unrecognised --log-level value causes argparse to exit non-zero."""
-                import pytest
+        """An unrecognised --log-level value causes argparse to exit non-zero."""
+        import pytest
 
         with patch("sys.argv", ["empathysync", "--log-level", "VERBOSE"]):
-                        with pytest.raises(SystemExit) as exc_info:
-                                            from src.cli import main
+            with pytest.raises(SystemExit) as exc_info:
+                from src.cli import main
 
-                            main()
+                main()
         assert exc_info.value.code != 0
 
 
 class TestListDomains:
-        def test_list_domains_prints_all_domains(self, capsys):
-                    """Test that list_domains prints all 8 domains with their risk weights."""
+    def test_list_domains_prints_all_domains(self, capsys):
+        """Test that list_domains prints all 8 domains with their risk weights."""
         from src.cli import list_domains
 
         list_domains()
@@ -118,7 +118,7 @@ class TestListDomains:
         assert "Suicidal ideation" in output or "Illegal activities" in output
 
     def test_list_domains_sorted_by_risk_weight(self, capsys):
-                """Test that domains are sorted by risk weight in descending order."""
+        """Test that domains are sorted by risk weight in descending order."""
         from src.cli import list_domains
 
         list_domains()
@@ -134,15 +134,15 @@ class TestListDomains:
 
         weights = []
         for line in domain_lines:
-                        match = re.search(r"risk weight:\s*([\d.]+)", line)
+            match = re.search(r"risk weight:\s*([\d.]+)", line)
             if match:
-                                weights.append(float(match.group(1)))
+                weights.append(float(match.group(1)))
 
         # Verify that weights are in descending order
         assert weights == sorted(weights, reverse=True)
 
     def test_list_domains_json_output_is_valid_json(self, capsys):
-                """--list-domains --json produces valid JSON output."""
+        """--list-domains --json produces valid JSON output."""
         from src.cli import list_domains
 
         list_domains(json_output=True)
@@ -158,12 +158,12 @@ class TestListDomains:
 
         # Each item must have the required keys
         for item in data:
-                        assert "domain" in item
+            assert "domain" in item
             assert "risk_weight" in item
             assert "description" in item
 
     def test_list_domains_json_contains_all_domains(self, capsys):
-                """--list-domains --json output contains all expected domains."""
+        """--list-domains --json output contains all expected domains."""
         from src.cli import list_domains
 
         list_domains(json_output=True)
@@ -173,11 +173,11 @@ class TestListDomains:
 
         domain_names = [item["domain"] for item in data]
         for expected in ["crisis", "harmful", "health", "money", "emotional",
-                                                  "relationships", "spirituality", "logistics"]:
-                                                                  assert expected in domain_names
+                         "relationships", "spirituality", "logistics"]:
+            assert expected in domain_names
 
     def test_list_domains_plain_text_unchanged_when_no_json_flag(self, capsys):
-                """Without --json, output is the original plain-text format."""
+        """Without --json, output is the original plain-text format."""
         from src.cli import list_domains
 
         list_domains(json_output=False)
@@ -188,32 +188,32 @@ class TestListDomains:
         assert "risk weight:" in output
 
     def test_json_flag_without_list_domains_is_ignored(self):
-                """--json without --list-domains causes no error and runs normally."""
+        """--json without --list-domains causes no error and runs normally."""
         with patch("src.cli.run_streamlit") as mock_run_streamlit:
-                        with patch("sys.argv", ["empathysync", "--json"]):
-                                            from src.cli import main
+            with patch("sys.argv", ["empathysync", "--json"]):
+                from src.cli import main
 
                 main()
         assert mock_run_streamlit.called
 
 
 class TestRunCLI:
-        def test_run_cli_invokes_adapter(self):
-                    """Test that run_cli actually wires up and calls adapter.run()."""
+    def test_run_cli_invokes_adapter(self):
+        """Test that run_cli actually wires up and calls adapter.run()."""
         mock_adapter_instance = MagicMock()
 
         with (
-                        patch("models.ai_wellness_guide.WellnessGuide"),
-                        patch("models.conversation_session.ConversationSession"),
-                        patch("utils.wellness_tracker.WellnessTracker"),
-                        patch("utils.trusted_network.TrustedNetwork"),
-                        patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter,
-):
+            patch("models.ai_wellness_guide.WellnessGuide"),
+            patch("models.conversation_session.ConversationSession"),
+            patch("utils.wellness_tracker.WellnessTracker"),
+            patch("utils.trusted_network.TrustedNetwork"),
+            patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter,
+        ):
 
-                mock_adapter.return_value = mock_adapter_instance
+            mock_adapter.return_value = mock_adapter_instance
 
             with patch("sys.argv", ["empathysync", "--mode", "cli"]):
-                                from src.cli import main
+                from src.cli import main
 
                 main()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,99 +1,100 @@
 """Tests for CLI mode."""
 
+import json
 import logging
 from unittest.mock import patch, MagicMock
 
 
 class TestCLIArguments:
-    def test_list_domains_flag_calls_list_domains(self):
-        with patch("src.cli.list_domains") as mock_list_domains:
-            with patch("sys.argv", ["empathysync", "--list-domains"]):
-                from src.cli import main
+        def test_list_domains_flag_calls_list_domains(self):
+                    with patch("src.cli.list_domains") as mock_list_domains:
+                                    with patch("sys.argv", ["empathysync", "--list-domains"]):
+                                                        from src.cli import main
 
-                main()
-            assert mock_list_domains.called
+                                        main()
+                                    assert mock_list_domains.called
 
-    def test_mode_cli_calls_run_cli(self):
-        with patch("src.cli.run_cli") as mock_run_cli:
-            with patch("sys.argv", ["empathysync", "--mode", "cli"]):
-                from src.cli import main
+                def test_mode_cli_calls_run_cli(self):
+                            with patch("src.cli.run_cli") as mock_run_cli:
+                                            with patch("sys.argv", ["empathysync", "--mode", "cli"]):
+                                                                from src.cli import main
 
-                main()
-            assert mock_run_cli.called
+                                                main()
+                                            assert mock_run_cli.called
 
-    def test_mode_web_calls_run_streamlit(self):
-        with patch("src.cli.run_streamlit") as mock_run_streamlit:
-            with patch("sys.argv", ["empathysync", "--mode", "web"]):
-                from src.cli import main
+                        def test_mode_web_calls_run_streamlit(self):
+                                    with patch("src.cli.run_streamlit") as mock_run_streamlit:
+                                                    with patch("sys.argv", ["empathysync", "--mode", "web"]):
+                                                                        from src.cli import main
 
-                main()
-            assert mock_run_streamlit.called
+                                                        main()
+                                                    assert mock_run_streamlit.called
 
-    def test_default_mode_calls_run_streamlit(self):
-        with patch("src.cli.run_streamlit") as mock_run_streamlit:
-            with patch("sys.argv", ["empathysync"]):
-                from src.cli import main
+                                def test_default_mode_calls_run_streamlit(self):
+                                            with patch("src.cli.run_streamlit") as mock_run_streamlit:
+                                                            with patch("sys.argv", ["empathysync"]):
+                                                                                from src.cli import main
 
-                main()
-            assert mock_run_streamlit.called
+                                                                main()
+                                                            assert mock_run_streamlit.called
 
-    def test_log_level_debug_sets_root_logger(self):
-        """--log-level DEBUG overrides the root logger level."""
-        root = logging.getLogger()
-        original = root.level
-        try:
-            with patch("src.cli.run_streamlit"):
-                with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
-                    from src.cli import main
+                                        def test_log_level_debug_sets_root_logger(self):
+                                                    """--log-level DEBUG overrides the root logger level."""
+                                                    root = logging.getLogger()
+                                                    original = root.level
+                                                    try:
+                                                                    with patch("src.cli.run_streamlit"):
+                                                                                        with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
+                                                                                                                from src.cli import main
 
-                    main()
-            assert root.level == logging.DEBUG
-        finally:
+                                                                                            main()
+                                                                                    assert root.level == logging.DEBUG
+finally:
             root.setLevel(original)
 
     def test_log_level_warning_sets_root_logger(self):
-        """--log-level WARNING overrides the root logger level."""
-        root = logging.getLogger()
-        original = root.level
-        try:
-            with patch("src.cli.run_streamlit"):
-                with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
-                    from src.cli import main
+                """--log-level WARNING overrides the root logger level."""
+                root = logging.getLogger()
+                original = root.level
+                try:
+                                with patch("src.cli.run_streamlit"):
+                                                    with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
+                                                                            from src.cli import main
 
-                    main()
-            assert root.level == logging.WARNING
-        finally:
+                                                        main()
+                                                assert root.level == logging.WARNING
+finally:
             root.setLevel(original)
 
     def test_log_level_absent_does_not_modify_root_logger(self):
-        """When --log-level is omitted, root logger level is left untouched."""
-        root = logging.getLogger()
-        root.setLevel(logging.ERROR)
-        try:
-            with patch("src.cli.run_streamlit"):
-                with patch("sys.argv", ["empathysync"]):
-                    from src.cli import main
+                """When --log-level is omitted, root logger level is left untouched."""
+                root = logging.getLogger()
+                root.setLevel(logging.ERROR)
+                try:
+                                with patch("src.cli.run_streamlit"):
+                                                    with patch("sys.argv", ["empathysync"]):
+                                                                            from src.cli import main
 
-                    main()
-            assert root.level == logging.ERROR
-        finally:
+                                                        main()
+                                                assert root.level == logging.ERROR
+finally:
             root.setLevel(logging.WARNING)
 
     def test_log_level_invalid_choice_exits_nonzero(self):
-        """An unrecognised --log-level value causes argparse to exit non-zero."""
-        import pytest
+                """An unrecognised --log-level value causes argparse to exit non-zero."""
+                import pytest
 
         with patch("sys.argv", ["empathysync", "--log-level", "VERBOSE"]):
-            from src.cli import main
+                        with pytest.raises(SystemExit) as exc_info:
+                                            from src.cli import main
 
-            with pytest.raises(SystemExit) as exc_info:
-                main()
+                            main()
         assert exc_info.value.code != 0
 
 
 class TestListDomains:
-    def test_list_domains_prints_all_domains(self, capsys):
-        """Test that list_domains prints all 8 domains with their risk weights."""
+        def test_list_domains_prints_all_domains(self, capsys):
+                    """Test that list_domains prints all 8 domains with their risk weights."""
         from src.cli import list_domains
 
         list_domains()
@@ -117,7 +118,7 @@ class TestListDomains:
         assert "Suicidal ideation" in output or "Illegal activities" in output
 
     def test_list_domains_sorted_by_risk_weight(self, capsys):
-        """Test that domains are sorted by risk weight in descending order."""
+                """Test that domains are sorted by risk weight in descending order."""
         from src.cli import list_domains
 
         list_domains()
@@ -133,31 +134,86 @@ class TestListDomains:
 
         weights = []
         for line in domain_lines:
-            match = re.search(r"risk weight:\s*([\d.]+)", line)
+                        match = re.search(r"risk weight:\s*([\d.]+)", line)
             if match:
-                weights.append(float(match.group(1)))
+                                weights.append(float(match.group(1)))
 
         # Verify that weights are in descending order
         assert weights == sorted(weights, reverse=True)
 
+    def test_list_domains_json_output_is_valid_json(self, capsys):
+                """--list-domains --json produces valid JSON output."""
+        from src.cli import list_domains
+
+        list_domains(json_output=True)
+
+        output = capsys.readouterr().out
+
+        # Must parse without error
+        data = json.loads(output)
+
+        # Must be a list
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        # Each item must have the required keys
+        for item in data:
+                        assert "domain" in item
+            assert "risk_weight" in item
+            assert "description" in item
+
+    def test_list_domains_json_contains_all_domains(self, capsys):
+                """--list-domains --json output contains all expected domains."""
+        from src.cli import list_domains
+
+        list_domains(json_output=True)
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        domain_names = [item["domain"] for item in data]
+        for expected in ["crisis", "harmful", "health", "money", "emotional",
+                                                  "relationships", "spirituality", "logistics"]:
+                                                                  assert expected in domain_names
+
+    def test_list_domains_plain_text_unchanged_when_no_json_flag(self, capsys):
+                """Without --json, output is the original plain-text format."""
+        from src.cli import list_domains
+
+        list_domains(json_output=False)
+
+        output = capsys.readouterr().out
+
+        assert output.startswith("Supported domains:")
+        assert "risk weight:" in output
+
+    def test_json_flag_without_list_domains_is_ignored(self):
+                """--json without --list-domains causes no error and runs normally."""
+        with patch("src.cli.run_streamlit") as mock_run_streamlit:
+                        with patch("sys.argv", ["empathysync", "--json"]):
+                                            from src.cli import main
+
+                main()
+        assert mock_run_streamlit.called
+
 
 class TestRunCLI:
-    def test_run_cli_invokes_adapter(self):
-        """Test that run_cli actually wires up and calls adapter.run()."""
+        def test_run_cli_invokes_adapter(self):
+                    """Test that run_cli actually wires up and calls adapter.run()."""
         mock_adapter_instance = MagicMock()
 
         with (
-            patch("models.ai_wellness_guide.WellnessGuide"),
-            patch("models.conversation_session.ConversationSession"),
-            patch("utils.wellness_tracker.WellnessTracker"),
-            patch("utils.trusted_network.TrustedNetwork"),
-            patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter,
-        ):
+                        patch("models.ai_wellness_guide.WellnessGuide"),
+                        patch("models.conversation_session.ConversationSession"),
+                        patch("utils.wellness_tracker.WellnessTracker"),
+                        patch("utils.trusted_network.TrustedNetwork"),
+                        patch("interfaces.cli_adapter.CLIAdapter") as mock_adapter,
+):
 
-            mock_adapter.return_value = mock_adapter_instance
+                mock_adapter.return_value = mock_adapter_instance
 
             with patch("sys.argv", ["empathysync", "--mode", "cli"]):
-                from src.cli import main
+                                from src.cli import main
 
                 main()
 


### PR DESCRIPTION
Closes #110

- Add `import json` to imports
- Add `json_output=False` parameter to `list_domains()`
- When `json_output=True`, print a JSON array of objects with `domain`, `risk_weight`, and `description` keys
- Add `--json` argument to the argparse parser
- Pass `args.json` to `list_domains()` in `main()`
- `--json` without `--list-domains` is silently ignored

## Summary

What does this PR do? (1-3 sentences)

## Changes

-
-
-

## Related Issues

Closes #

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [ ] Manually tested (if applicable)
- [ ] New tests added for new functionality (if applicable)

## Screenshots

If this changes the UI, include before/after screenshots.
