### PR TITLE
docs: pre-release cleanup - CHANGELOG, ROADMAP, architecture, CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to empathySync are documented here.
 
+## [Unreleased] - Security Hardening & CLI Completeness
+
+**"Safer by default. More scriptable at the edge."**
+
+### Security
+- Prompt injection hardening: user input in the LLM classification prompt is now wrapped in `<user_message>` XML boundary tags before template formatting, preventing crafted inputs from escaping the message field and influencing classifier instructions (#93)
+- Streaming safety buffer: the response stream now accumulates tokens in a 200-character rolling buffer before yielding to the UI. `_contains_harmful_content()` runs on each buffer flush rather than only after the full response - harmful content is intercepted mid-stream rather than after it has partially rendered (#94)
+
+### New
+- `--log-level` CLI flag: overrides the root logger level at startup (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Takes precedence over the `LOG_LEVEL` env var. Useful for debugging without touching `.env` (#99)
+- `--list-domains --json` flag: `--list-domains` now accepts `--json` to emit a machine-readable JSON array instead of plain text. Each object contains `domain`, `risk_weight`, and `description`. Useful for scripting and tooling built on top of empathySync (#110, @FTFaruque)
+
+### Docs
+- `--maintenance` and `--log-level` added to the README CLI usage block (#109, @ded-furby)
+
+### Tests
+- 4 new tests for `--json` flag covering valid JSON output, all 8 domains present, plain-text regression, and `--json` alone being silently ignored
+- 4 new tests for `--log-level` covering DEBUG, WARNING, absent flag leaving level untouched, and invalid value exiting non-zero
+- 1 new test for XML boundary wrapping in `_build_prompt()`
+- 1 new test for mid-stream harmful content interception via the rolling buffer
+
+---
+
 ## v1.10.1 (2026-06-01) - Documentation Accuracy
 
 **"The docs should say what the code does."**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,12 @@ pip install -r requirements.txt  # Alternative: just core deps
 # Run the application
 streamlit run src/app.py    # Direct
 empathysync                 # Via CLI entry point (after pip install -e .)
+empathysync --mode cli      # Terminal mode (no browser)
+empathysync --log-level DEBUG  # Override log verbosity (DEBUG, INFO, WARNING, ERROR)
+empathysync --list-domains     # List all supported classification domains
+empathysync --list-domains --json  # Same, as machine-readable JSON
+empathysync --maintenance   # Prune old data, check integrity, print summary
+empathysync --version       # Print version and exit
 
 # Docker (app + Ollama together)
 docker compose up           # Starts both services
@@ -409,6 +415,8 @@ When another device holds the lock (`ENABLE_DEVICE_LOCK=true`), all write operat
 - **Type-Safe Enums**: `str, Enum` pattern for backward-compatible domain/intent constants (Phase 16.5)
 - **Storage Backend Abstraction**: Unified interface for JSON/SQLite with automatic migration (Phase 11)
 - **Streaming Response**: `generate_response_stream()` yields tokens progressively for real-time display (Phase 16)
+- **XML Prompt Boundary**: User input wrapped in `<user_message>` tags before LLM classification prompt is formatted - prevents prompt injection via crafted inputs escaping the message field (`src/models/llm_classifier.py`)
+- **Mid-Stream Safety Buffer**: 200-character rolling buffer in `generate_response_stream()` - `_contains_harmful_content()` runs on each flush so harmful tokens are intercepted before reaching the UI, not only after the full response (`src/models/ai_wellness_guide.py`)
 
 ## Documentation Maintenance
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2565,6 +2565,7 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 **v1.3** (Phase 16.9-16.10): Test coverage expansion, observability, configuration extraction ✅ COMPLETE
 **v1.4** (Phase 16.11): Conversation testing, voice tuning, golden response test suite
 **v1.5** (Phase 17.1-17.4): Multi-label distress routing, confidence calibration, distress corpus CI gate, sanity check refinement ✅ IN PROGRESS
+**vNext** (pending): Prompt injection hardening, streaming safety buffer, `--log-level` and `--json` CLI flags, first external code contributions - 🔜 RELEASE PENDING
 **v2.0** (Phase 18): Messaging integration, safety parity across all interfaces - DEFERRED
 **v2.1** (Phase 19): Multilingual support -crisis detection, restraint behaviour, and YAML knowledge base in priority languages
 **v2.2** (Phase 20): Native installer (Windows/Mac/Linux), first-run wizard, release CI builds - DEFERRED

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,11 @@ User Input
 ┌─────────────────────────────────────────────┐
 │  3. RISK ASSESSMENT                         │
 │     RiskClassifier.classify()               │
+│     User input wrapped in <user_message>    │
+│     XML tags before LLM classification      │
+│     prompt is formatted - prevents crafted  │
+│     inputs from escaping the message field  │
+│     (prompt injection hardening)            │
 │     LLM returns multi-label output:         │
 │       domain, emotional_intensity,          │
 │       dependency_risk, risk_weight,         │
@@ -174,14 +179,21 @@ User Input
 ┌─────────────────────────────────────────────┐
 │  OLLAMA API CALL (Streaming)                │
 │     Local LLM generates response            │
-│     Tokens stream as generated              │
+│     Tokens accumulated in 200-char rolling  │
+│     buffer before yielding to UI            │
+│     _contains_harmful_content() runs on     │
+│     each buffer flush (mid-stream check)    │
+│     Harmful content intercepted before it   │
+│     reaches the UI - safe alternative       │
+│     response substituted immediately        │
 └─────────────────────────────────────────────┘
     │
     ▼
 ┌─────────────────────────────────────────────┐
-│  SAFETY CHECK                               │
+│  SAFETY CHECK (post-stream backstop)        │
 │     _contains_harmful_content()             │
-│     Verify response is safe before display  │
+│     Second pass on full accumulated         │
+│     response as defense-in-depth            │
 └─────────────────────────────────────────────┘
     │
     ▼
@@ -515,7 +527,7 @@ data/
 empathySync/
 ├── src/                          # Application source code
 │   ├── app.py                   # Streamlit entry point
-│   ├── cli.py                   # CLI entry point (--mode web|cli)
+│   ├── cli.py                   # CLI entry point (--mode web|cli, --log-level, --list-domains --json)
 │   ├── config/
 │   │   └── settings.py          # Environment configuration
 │   ├── models/


### PR DESCRIPTION
## Summary

Documentation pass before the next release. No code changes.

- CHANGELOG: adds `[Unreleased]` section covering everything merged since v1.10.1 - prompt injection hardening, streaming safety buffer, `--log-level`, `--json` flag, README docs, and all new tests
- ROADMAP: adds `vNext` entry marking the pending release
- docs/architecture.md: safety pipeline diagram updated to show mid-stream buffer check and XML prompt boundary; `cli.py` directory entry updated with new flags
- CLAUDE.md: full CLI flag list added to development commands; XML Prompt Boundary and Mid-Stream Safety Buffer added to Key Patterns