### PR TITLE
fix: add eschatology keywords and pastor-trust examples to spirituality classifier

### DIFF
--- a/scenarios/classification/llm_classifier.yaml
+++ b/scenarios/classification/llm_classifier.yaml
@@ -433,6 +433,46 @@ examples:
       isolation_level: "active"
     explanation: "Direct active isolation - clear absence of support network."
 
+  # Eschatology and scripture interpretation - spirituality, NOT logistics
+  # Even when framed as intellectual questions, end-times topics are spirituality domain
+  - message: "do you think AI will mark the end of the world according to the book of revelation"
+    classification:
+      domain: "spirituality"
+      emotional_intensity: 3
+      is_personal_distress: false
+      is_practical_technique: false
+      confidence: 0.9
+    explanation: "Scripture interpretation question about end times. References the Book of Revelation directly - spirituality domain even when framed intellectually. Not a logistics/factual question."
+
+  - message: "is AI the antichrist or the mark of the beast?"
+    classification:
+      domain: "spirituality"
+      emotional_intensity: 4
+      is_personal_distress: false
+      is_practical_technique: false
+      confidence: 0.9
+    explanation: "Eschatological question referencing biblical prophecy. Spirituality domain regardless of the technology angle."
+
+  # Trust in religious authority - spirituality, NOT relationships
+  # Doubting a pastor/priest/imam is a spiritual trust issue, not a generic relationship issue
+  - message: "I think my pastor is lying to us"
+    classification:
+      domain: "spirituality"
+      emotional_intensity: 6
+      is_personal_distress: true
+      is_practical_technique: false
+      confidence: 0.9
+    explanation: "Distrust of a religious authority figure. This is a spirituality domain issue - faith and institutional trust - not a generic relationships question."
+
+  - message: "my pastor said something that doesn't feel right, I don't know if I can trust him anymore"
+    classification:
+      domain: "spirituality"
+      emotional_intensity: 7
+      is_personal_distress: true
+      is_practical_technique: false
+      confidence: 0.9
+    explanation: "Crisis of trust in religious leadership. Spirituality domain - touches on church hurt and spiritual authority, not just interpersonal conflict."
+
 # Keywords that ALWAYS trigger fast-path (safety-critical, skip LLM)
 # These bypass LLM classification entirely for safety
 fast_path_crisis:

--- a/scenarios/domains/spirituality.yaml
+++ b/scenarios/domains/spirituality.yaml
@@ -85,6 +85,14 @@ triggers:
 
   # === Religious authority and texts ===
   - pastor said
+  - pastor is
+  - pastor lied
+  - pastor lying
+  - my pastor
+  - my priest
+  - my imam
+  - my rabbi
+  - my church
   - priest said
   - imam said
   - rabbi said
@@ -96,12 +104,38 @@ triggers:
   - vedas
   - bhagavad gita
   - book of mormon
+  - book of revelation
   - hadith
   - gospel
   - sermon
   - church teaching
   - doctrine
   - theological
+
+  # === Eschatology and end times ===
+  - end of the world
+  - end times
+  - end of days
+  - last days
+  - second coming
+  - rapture
+  - tribulation
+  - great tribulation
+  - armageddon
+  - antichrist
+  - mark of the beast
+  - "666"
+  - beast system
+  - four horsemen
+  - revelation prophecy
+  - biblical prophecy
+  - prophecy fulfilled
+  - apocalypse
+  - apocalyptic
+  - day of judgment
+  - day of reckoning
+  - signs of the times
+  - new world order prophecy
 
   # === Spiritual decisions ===
   - is it a sin


### PR DESCRIPTION
## Summary

Two classification gaps identified from live testing:

1. **Eschatology miss** - \"do you think AI will mark the end of the world according to the book of revelation\" was classified as `logistics` (practical task). No end-times keywords existed in the spirituality domain triggers at all.

2. **Pastor-trust miss** - \"I think my pastor is lying\" fell through to `relationships` or `logistics`. The trigger list had `pastor said` but not `my pastor`, `pastor is`, or `pastor lying`.

## Changes

**`scenarios/domains/spirituality.yaml`**
- New eschatology section: end times, rapture, tribulation, armageddon, antichrist, mark of the beast, 666, four horsemen, revelation prophecy, apocalypse, day of judgment, signs of the times
- Expanded religious authority triggers: `my pastor`, `pastor is`, `pastor lying`, `pastor lied`, `my priest`, `my imam`, `my rabbi`, `my church`
- Fixed: `666` quoted as string to prevent YAML parsing it as integer (would crash the keyword classifier)

**`scenarios/classification/llm_classifier.yaml`**
- 4 new examples: AI + end-times question, antichrist framing, pastor-trust issue, nuanced pastor-doubt phrasing

## Testing

- `pytest tests/` - 971 passed (excluding pre-existing `stress_test_001_relationship_suspicion` flake which fails on unmodified main)
- YAML schema validation passes
- No duplicate triggers