### PR TITLE
fix: honest isolation handling when network empty; surface steering in mode label

### DIFF
--- a/src/models/conversation_result.py
+++ b/src/models/conversation_result.py
@@ -38,6 +38,7 @@ class ConversationResult:
     # Session metadata
     turn_count: int = 0
     should_rerun: bool = False
+    steering_active: bool = False
 
     # Streaming support: when set, response_stream yields tokens progressively
     response_stream: Optional[Iterator[str]] = None

--- a/src/models/conversation_session.py
+++ b/src/models/conversation_session.py
@@ -43,11 +43,13 @@ class ConnectionSteering:
 
     active: bool = False
     first_detected_turn: int = 0
+    network_empty: bool = False
 
-    def activate(self, turn_count: int) -> None:
+    def activate(self, turn_count: int, network_empty: bool = False) -> None:
         """Activate steering, recording when it was first triggered."""
         self.active = True
         self.first_detected_turn = turn_count
+        self.network_empty = network_empty
 
 
 def _load_confidence_threshold() -> float:
@@ -187,7 +189,10 @@ class ConversationSession:
         # so steering context can be injected into this response immediately.
         if not self.connection_steering.active:
             if self._check_isolation_signals(user_input):
-                self.connection_steering.activate(self.turn_count)
+                self.connection_steering.activate(
+                    self.turn_count,
+                    network_empty=len(self.network.get_all_people()) == 0,
+                )
 
         # Step 4: Generate response via WellnessGuide safety pipeline
         response = self.guide.generate_response(
@@ -205,7 +210,10 @@ class ConversationSession:
         if not self.connection_steering.active and self.guide.last_risk_assessment:
             isolation_level = self.guide.last_risk_assessment.get("isolation_level", "none")
             if isolation_level in ("active", "passive"):
-                self.connection_steering.activate(self.turn_count)
+                self.connection_steering.activate(
+                    self.turn_count,
+                    network_empty=len(self.network.get_all_people()) == 0,
+                )
 
         # Step 5: Track task category for practical tasks
         should_check_graduation = False
@@ -266,6 +274,7 @@ class ConversationSession:
             suggested_handoff_domain=suggested_domain,
             turn_count=self.turn_count,
             should_rerun=should_rerun,
+            steering_active=self.connection_steering.active,
         )
 
     def process_message_stream(self, user_input: str) -> ConversationResult:
@@ -339,7 +348,10 @@ class ConversationSession:
         # Step 3.5: Isolation detection - keyword fast-path before LLM call
         if not self.connection_steering.active:
             if self._check_isolation_signals(user_input):
-                self.connection_steering.activate(self.turn_count)
+                self.connection_steering.activate(
+                    self.turn_count,
+                    network_empty=len(self.network.get_all_people()) == 0,
+                )
 
         # Step 4: Get streaming generator from WellnessGuide
         stream = self.guide.generate_response_stream(
@@ -359,6 +371,7 @@ class ConversationSession:
             response_stream=stream,
             pending_shift=self.pending_shift,
             turn_count=self.turn_count,
+            steering_active=self.connection_steering.active,
         )
 
     def finalize_stream(self) -> ConversationResult:
@@ -381,7 +394,10 @@ class ConversationSession:
         if not self.connection_steering.active and self.guide.last_risk_assessment:
             isolation_level = self.guide.last_risk_assessment.get("isolation_level", "none")
             if isolation_level in ("active", "passive"):
-                self.connection_steering.activate(self.turn_count)
+                self.connection_steering.activate(
+                    self.turn_count,
+                    network_empty=len(self.network.get_all_people()) == 0,
+                )
 
         # Step 5: Track task category for practical tasks
         should_check_graduation = False
@@ -442,6 +458,7 @@ class ConversationSession:
             suggested_handoff_domain=suggested_domain,
             turn_count=self.turn_count,
             should_rerun=should_rerun,
+            steering_active=self.connection_steering.active,
         )
 
     def _log_perf(self, t_start: float) -> None:

--- a/src/prompts/wellness_prompts.py
+++ b/src/prompts/wellness_prompts.py
@@ -229,7 +229,22 @@ If the user asks for advice on: {forbidden_text}—respond ONLY with:
         no deflection tracking. The modifier changes tone and texture, not topic.
         """
         config = self.loader.get_connection_steering_config()
-        return config.get("steering", {}).get("system_prompt_addition", "").strip()
+        base = config.get("steering", {}).get("system_prompt_addition", "").strip()
+
+        if getattr(connection_steering, "network_empty", False):
+            base += (
+                "\n\nADDITIONAL CONTEXT - USER HAS NO EXISTING CONTACTS:\n"
+                "The user has no configured support contacts. Do not hint that they should "
+                "reach out to a specific person - there may be no one to reach out to yet.\n"
+                "If connection or loneliness comes up naturally in conversation, you may "
+                "briefly acknowledge that building connection takes time - it does not happen "
+                "overnight and that is normal. You can mention in passing that connection tends "
+                "to happen through shared activities (community groups, volunteering, classes) "
+                "rather than forced socialising. One light mention at most, only when it fits "
+                "naturally. Never push it."
+            )
+
+        return base
 
     def get_check_in_prompts(self) -> List[str]:
         """Get various check-in prompts for user reflection."""

--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -62,6 +62,7 @@ def display_chat_interface(wellness_mode):
                 display_response_mode_label(
                     message["risk_assessment"],
                     message.get("policy_action"),
+                    steering_active=message.get("steering_active", False),
                 )
 
     # Welcome screen when no messages yet
@@ -130,6 +131,7 @@ def display_chat_interface(wellness_mode):
             display_response_mode_label(
                 result.risk_assessment,
                 guide.last_policy_action,
+                steering_active=result.steering_active,
             )
 
         # Attach risk data to the last assistant message so the label
@@ -137,6 +139,7 @@ def display_chat_interface(wellness_mode):
         if session.messages and session.messages[-1]["role"] == "assistant":
             session.messages[-1]["risk_assessment"] = result.risk_assessment
             session.messages[-1]["policy_action"] = guide.last_policy_action
+            session.messages[-1]["steering_active"] = result.steering_active
 
         # Sync messages reference for backward compatibility
         st.session_state.messages = session.messages

--- a/src/ui/panels.py
+++ b/src/ui/panels.py
@@ -10,7 +10,9 @@ from utils.scenario_loader import get_scenario_loader
 from models.risk_classifier import INTENT_PRACTICAL, INTENT_CONNECTION
 
 
-def display_response_mode_label(risk_assessment: dict, policy_action: dict = None) -> None:
+def display_response_mode_label(
+    risk_assessment: dict, policy_action: dict = None, steering_active: bool = False
+) -> None:
     """
     Inline one-line summary shown directly under each assistant response (Phase 17.6).
 
@@ -56,6 +58,9 @@ def display_response_mode_label(risk_assessment: dict, policy_action: dict = Non
         parts.append(policy_labels[policy_type])
     elif not is_practical:
         parts.append("keeping it brief")
+
+    if steering_active:
+        parts.append("connection awareness active")
 
     st.caption("  ·  ".join(parts))
 


### PR DESCRIPTION
## Summary

Two targeted fixes responding to feedback that empathySync:
1. Redirects isolated users to people who may not exist
2. Changes response texture without telling the user

## Change 1 - Loneliness gap

When isolation is detected and the trusted network is empty, the old behaviour
was to activate connection steering (good) but still lean on the assumption
that someone exists to reach out to (not good).

**What changed:**
- `ConnectionSteering` gains `network_empty: bool` flag
- All four `activate()` call sites (keyword fast-path + LLM-detected, sync + stream) now check `len(network.get_all_people()) == 0` and pass it through
- `_get_connection_steering_addition()` in `wellness_prompts.py` appends an extra system prompt block when `network_empty` is True: don't redirect to specific people; acknowledge building connection takes time; mention shared-activity pathways only if it fits naturally

## Change 2 - Transparency

Connection steering changes the texture of every response once active. Users
had no way to see this was happening.

**What changed:**
- `ConversationResult` gains `steering_active: bool`
- All three result-return sites pass `connection_steering.active`
- `chat.py` stores it in the message dict and forwards to the mode label
- `display_response_mode_label()` appends **"connection awareness active"** to the caption when steering is on

The mode label now reads e.g.: `Responded as: practical task · connection awareness active`

## Testing

- 971 tests pass (pre-existing `stress_test_001_relationship_suspicion` flake excluded - fails on unmodified main too)