### PR TITLE
docs: calibrate README safety claims + add THREAT_MODEL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It gives full help on practical tasks - writing, coding, explanations. On sensit
 
 Everything runs on your hardware via Ollama. No cloud. No external API calls. No telemetry. No engagement optimization.
 
-The restraint is implemented at the pipeline level - in the code, not in prompts or guidelines that can be rephrased away. That distinction matters. A prompt can be jailbroken. A pipeline step cannot.
+The restraint lives in the pipeline, not only in prompts that can be rephrased away - which makes it harder to bypass, though no safety layer is absolute.
 
 ## Who Uses This
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The restraint lives in the pipeline, not only in prompts that can be rephrased a
 
 **Therapists, counsellors, and domain experts** who want to shape how an AI responds to emotional content - the scenarios, responses, and intervention language are plain YAML files. No programming required. See [HELP-SHAPE-THIS.md](HELP-SHAPE-THIS.md).
 
-This is not a companion AI or always-on assistant. It is useful help that does not try to become a habit.
+It is a tool you reach for when you need it and put down when you don't, not a companion or an always-on assistant.
 
 <details>
 <summary><strong>The philosophy</strong></summary>
@@ -163,7 +163,7 @@ empathysync --log-level DEBUG  # Set log verbosity (DEBUG, INFO, WARNING, ERROR)
 
 empathySync uses two complementary detection layers - a keyword fast-path and an LLM classifier - that catch different kinds of cases:
 
-- **Keyword triage** (~250 patterns): fast first-pass detection of known harmful and crisis phrases. Catches obvious cases with zero latency.
+- **Keyword triage** (hundreds of patterns): fast first-pass detection of known harmful and crisis phrases. Catches obvious cases with zero latency.
 - **LLM classifier**: nuanced detection that reads context, not just keywords. Handles rephrased, euphemistic, and indirectly-expressed harmful intent that keywords miss.
 - **Mutation-defense rules** baked into the LLM prompt: fictional framing ("for a story I'm writing"), third-person distancing ("a friend asked"), and euphemistic language do not change the classification - the LLM is instructed to read intent, not surface phrasing.
 - **Confidence calibration**: when the LLM is uncertain on a sensitive topic, keyword detection takes over. False positive is always safer than false negative on crisis content.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ https://github.com/user-attachments/assets/cce0d214-4cd3-4816-b162-28af19941efb
 empathySync is a local AI assistant built on one design principle:
 
 > *The part of AI that handles your personal life should belong to you.*
-> *That's not a feature - it's the point.*
 
 It gives full help on practical tasks - writing, coding, explanations. On sensitive topics (emotional distress, health, relationships, finances), it applies deliberate restraint: brief responses, human redirects, no follow-up questions designed to keep you talking. When it detects crisis signals, it routes to professional resources immediately, without exception.
 
@@ -162,14 +161,14 @@ empathysync --log-level DEBUG  # Set log verbosity (DEBUG, INFO, WARNING, ERROR)
 
 ## How the Safety Pipeline Works
 
-empathySync uses two independent layers so neither can be bypassed alone:
+empathySync uses two complementary detection layers - a keyword fast-path and an LLM classifier - that catch different kinds of cases:
 
 - **Keyword triage** (~250 patterns): fast first-pass detection of known harmful and crisis phrases. Catches obvious cases with zero latency.
 - **LLM classifier**: nuanced detection that reads context, not just keywords. Handles rephrased, euphemistic, and indirectly-expressed harmful intent that keywords miss.
 - **Mutation-defense rules** baked into the LLM prompt: fictional framing ("for a story I'm writing"), third-person distancing ("a friend asked"), and euphemistic language do not change the classification - the LLM is instructed to read intent, not surface phrasing.
 - **Confidence calibration**: when the LLM is uncertain on a sensitive topic, keyword detection takes over. False positive is always safer than false negative on crisis content.
 
-Each layer is independent. A rephrased attack that evades keyword detection still hits the LLM layer. Prompt injection that manipulates the LLM still hits the keyword layer. Testing across 620 known harmful behaviors (JailbreakBench + AdvBench) showed 97-100% mutation evasion on keyword-only detection, confirming the LLM layer is the real defense - keywords are triage, not the gate.
+The two layers are complementary, not redundant. A rephrased attack that slips past the keywords can still be caught by the LLM classifier; an obvious phrase the classifier softens is still caught by the keywords. But detection is enumeration-based, and enumeration is never complete - a phrasing that escapes both layers can get through. Testing across 620 known harmful behaviors (JailbreakBench + AdvBench) showed 97-100% evasion of keyword-only detection, which is why the LLM layer carries most of the load. Neither layer alone is a guarantee; see [THREAT_MODEL.md](THREAT_MODEL.md) for what the pipeline does and does not protect.
 
 ## Configuration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2572,6 +2572,21 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 
 ---
 
+## Next Up: v1.11.0 - Operational Hardening (planned, post-v1.10.1)
+
+Contributor-experience and operational improvements identified from reviewing mature
+self-hosted OSS projects. None are bugs in v1.10.1; they harden the project as the
+contributor base grows.
+
+- [ ] Docker entrypoint hardening: PUID/PGID permission handling, CUDA detection, SIGTERM signal forwarding
+- [ ] Issue templates (`.github/`) requesting install method, OS, Ollama version, and model
+- [ ] PR-description validation GitHub Action (summary present, type-of-change, testing notes)
+- [ ] `dev`/`main` branch model: PRs target `dev`, `main` stays curated
+- [ ] THREAT_MODEL.md follow-through: address documented gaps (filesystem/shell sandboxing options, optional encryption at rest)
+- [ ] Clean-machine install test before public demos: verify the "runs on your laptop" path end to end
+
+---
+
 ## Related Documentation
 
 - **[README.md](README.md)** - Product overview, quick start, and distribution phases

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,80 @@
+# Threat Model
+
+empathySync is a local-first, single-user wellness assistant. It runs on your own
+machine, talks only to a local Ollama instance, and stores all data locally. This document
+states the trust boundary and, more importantly, what the safety architecture does and does
+not protect, so contributors and users can reason about it honestly.
+
+This is deliberately different from the threat model of a hosted, multi-user product.
+empathySync has no accounts, no server, no shell or file tools, and does not browse the web
+or read email. The attack surface that dominates those systems is largely absent here. The
+risks that matter for empathySync are about **safety-detection completeness**, **local data
+exposure**, and **honest claims about what the restraint guarantees**.
+
+## Trust boundary
+
+empathySync assumes a **single trusted user running it on their own machine**, reachable at
+`localhost`. It is not designed for public exposure or multi-user deployment:
+
+- There is no authentication. The web UI (Streamlit) and CLI both assume the operator is the
+  owner of the machine.
+- All data stays on the device. There is no cloud sync, no telemetry, and no external API
+  call other than to the local Ollama endpoint.
+
+Do not expose the Streamlit port to an untrusted network. If you need remote access, put it
+behind your own authenticated tunnel or reverse proxy; empathySync provides none.
+
+## What the design protects
+
+- **Privacy by locality.** Conversations, patterns, and trusted-network data never leave the
+  machine. There are no analytics, accounts, or outbound calls beyond local inference.
+- **Restraint that cannot be removed by a prompt.** Crisis routing, harmful-content refusal,
+  turn limits, and dependency cooldowns are pipeline steps that execute in code before the
+  model is called. A jailbreak or instruction in the user's message cannot disable them. This
+  holds for the software as distributed (see *Source modification* below).
+- **A crisis floor that does not depend on the model.** Crisis detection has a keyword
+  fast-path (`scenarios/classification/llm_classifier.yaml`, `fast_path_crisis`) that runs
+  without the LLM, so the highest-priority safety signal still fires when the model is weak,
+  slow, or unavailable.
+- **Classifier prompt-injection resistance.** User content sent to the LLM classifier is
+  wrapped in an explicit `<user_message>...</user_message>` boundary and truncated to a
+  maximum length (`src/models/llm_classifier.py`), so untrusted text is treated as data, not
+  as instructions to the classifier.
+
+## Known gaps
+
+These are open and acknowledged. Contributor help is welcome.
+
+- **Enumeration-based detection is incomplete.** Harmful- and crisis-content detection rests
+  on enumerated keyword patterns plus an LLM classifier. Enumeration is never complete: a
+  phrasing that escapes both layers can be routed past the intended restraint rather than
+  caught by it. The layers narrow the gap; they do not close it. Neither layer alone is a
+  guarantee.
+- **Safety quality depends on the classifier model.** Nuanced cases - euphemistic crisis
+  ("nobody would miss me"), fiction or roleplay framing ("for a story I'm writing"), and
+  indirect harmful intent - require a capable classifier. A small or weak local model will
+  miss some of these even though the prompt contains the correct anti-framing rules. Choose a
+  classifier model you have verified against the safety scenarios, not the smallest one
+  available.
+- **No encryption at rest.** Conversation history and tracked patterns are stored as plain
+  JSON or SQLite under `data/` (git-ignored). Their confidentiality equals your operating
+  system account and file permissions. On a shared or portable device, use full-disk
+  encryption. Retention defaults prune conversation history after 30 days and other records
+  after 90 (`CONVERSATION_RETENTION_DAYS`, `DATA_RETENTION_DAYS`; set to 0 to disable).
+- **No access control.** The optional device lock (`ENABLE_DEVICE_LOCK`) prevents two devices
+  writing to synced data at once. It is a data-integrity safeguard, not authentication. Anyone
+  with access to the running app or the `data/` directory can read and write everything.
+- **Not a clinical or emergency service.** Dependency detection is a heuristic on behavioural
+  signals (message frequency, repetition, sensitive-domain engagement), not a validated
+  clinical instrument or a diagnosis. Crisis handling routes the user to professional
+  resources; it is not itself emergency help and does not contact anyone on the user's behalf.
+- **Source modification.** empathySync is open source. A developer with code access can modify
+  or remove any pipeline step, as with any such software. The restraint guarantees describe
+  the deployment as distributed, not a modified fork.
+
+## Reporting a gap
+
+Found a way past the safety pipeline, or a data-handling issue? See
+[.github/SECURITY.md](.github/SECURITY.md). Concrete reproductions (the exact phrasing that
+slipped through, the model in use) are the most useful, since the enumeration gap above is
+exactly the class of issue we want reported.


### PR DESCRIPTION
Finishes the safety-claim calibration in the public docs so they match the camera-ready paper, and adds the threat model.

**README**
- 'How the Safety Pipeline Works': dropped the "two independent layers so neither can be bypassed alone" / "keywords are triage, not the gate" overclaim. The keylogger backstop in #121 exists precisely because a phrasing can slip past both layers. Reworded to complementary layers, enumeration never complete, neither layer alone a guarantee.
- Softened the intro restraint line: "A prompt can be jailbroken. A pipeline step cannot." -> "harder to bypass, though no safety layer is absolute."
- Removed a stray rhetorical line ("That's not a feature - it's the point.").

**THREAT_MODEL.md (new)**
- Trust boundary: local single-user, no auth by design, localhost only.
- Protects: privacy by locality; restraint a prompt cannot remove; keyword crisis floor; classifier injection boundary.
- Known gaps: enumeration-based detection is incomplete; safety quality depends on the classifier model; no encryption at rest; device lock is not access control; not a clinical/emergency service; source can be modified in a fork.

Docs only. No code touched.