### PR TITLE
chore: add PR validation workflow and update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,10 @@ If applicable, add screenshots (especially of the Transparency panel).
 ## Environment
 - OS: [e.g., Ubuntu 22.04, Windows 11, macOS 14]
 - Python version: [e.g., 3.10]
-- Ollama model: [e.g., llama2, llama3]
-- Browser: [e.g., Chrome, Firefox]
+- Install method: [e.g., `bash install.sh`, `pip install -e .`, Docker]
+- Ollama version: [e.g., 0.17.0 — run `ollama --version`]
+- Ollama model: [e.g., gemma3:12b, llama3.2]
+- Browser (if UI issue): [e.g., Chrome, Firefox]
 
 ## Additional Context
 - Did this work before?

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,38 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'EOF'
+          import os, sys
+          body = os.environ.get("PR_BODY", "")
+          errors = []
+
+          if "## Summary" not in body:
+              errors.append("Missing ## Summary section")
+          else:
+              after_summary = body.split("## Summary", 1)[1].split("##")[0].strip()
+              if not after_summary:
+                  errors.append("## Summary section is empty - describe what the PR does")
+
+          if "## Testing" not in body:
+              errors.append("Missing ## Testing section")
+
+          if errors:
+              print("PR description is incomplete:\n")
+              for e in errors:
+                  print(f"  - {e}")
+              print("\nSee .github/PULL_REQUEST_TEMPLATE.md for the expected format.")
+              sys.exit(1)
+
+          print("PR description looks good.")
+          EOF


### PR DESCRIPTION
## Summary

Two contributor-experience improvements from issue #126:

- Adds `.github/workflows/pr-validation.yml`: GitHub Action that checks every PR has a non-empty `## Summary` and a `## Testing` section before CI passes. Fails with a clear message pointing to the PR template.
- Updates `.github/ISSUE_TEMPLATE/bug_report.md`: adds install method and Ollama version fields to the Environment section - the two most common missing pieces in bug reports.

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [ ] PR validation action syntax valid (will confirm on CI)

## What this does NOT include (from #126)

- `dev`/`main` branch model - needs explicit decision on repo settings before touching
- Docker entrypoint hardening - separate scope, own PR
- Clean-machine install test - process item, not a code change

Partially closes #126.