### PR TITLE
feat: Docker entrypoint hardening + docs-only CI skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs-only changes
+        id: docs-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          changed=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          non_docs=$(echo "$changed" | grep -Ev '^(docs/|.*\.md$|\.github/[^/]+\.md$)' || true)
+          if [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change — skipping test suite."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: steps.docs-check.outputs.docs_only != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
+        if: steps.docs-check.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -30,18 +53,22 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
       - name: Install dependencies
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-cov "black==25.9.0" flake8
 
       - name: Check formatting (black)
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: black --check --config pyproject.toml src/
 
       - name: Lint (flake8)
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: flake8 src/ --max-line-length=100 --ignore=E501,W503,E203,E402,F401,F841,F541,F824,E722
 
       - name: Run tests
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: pytest tests/ -v --tb=short
 
   validate-scenarios:
@@ -49,16 +76,40 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for docs-only changes
+        id: docs-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          changed=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          non_docs=$(echo "$changed" | grep -Ev '^(docs/|.*\.md$|\.github/[^/]+\.md$)' || true)
+          if [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change — skipping scenario validation."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python
+        if: steps.docs-check.outputs.docs_only != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install PyYAML
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: pip install pyyaml
 
       - name: Validate scenario YAML files
+        if: steps.docs-check.outputs.docs_only != 'true'
         run: python scripts/validate_scenarios.py
 
   manifesto-guard:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Infrastructure
+- Docker entrypoint hardening: PUID/PGID privilege drop via `gosu`, bind-mount ownership repair on restart, SIGTERM forwarding to Streamlit; localhost-only port binding in `docker-compose.yml` (was `0.0.0.0`) (#130)
+- CI: docs-only PRs now skip expensive test, lint, and scenario-validation steps while still reporting a passing check (#130)
+- PR validation GitHub Action: blocks PRs missing a `## Summary` or `## Testing` section (#129)
+- Bug report template: added install method and Ollama version fields to environment section (#129)
+
 ### Docs
 - `THREAT_MODEL.md` added: states the trust boundary (local single-user, no auth by design, localhost only) and the known gaps - enumeration-based harmful/crisis detection is incomplete, safety quality depends on the classifier model, no encryption at rest, the device lock is not access control, and it is not a clinical/emergency service; includes the 620-behaviour keyword-only evasion benchmark (97-100%, JailbreakBench + AdvBench) as evidence for the enumeration gap (#122)
 - `README.md` safety section leaned out: removed the "two independent layers so neither can be bypassed alone" / "keywords are triage, not the gate" overclaim (contradicted by the #121 keylogger backstop) and condensed "How the Safety Pipeline Works" to two layers plus pointers to `THREAT_MODEL.md` and `docs/architecture.md` (benchmark detail moved into the threat model). Keyword count corrected "~250" -> "hundreds". Removed the redundant intro pipeline-restraint sentence; tightened the "tool, not a companion" line; removed a stray rhetorical line (#122)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.12-slim
 
+# gosu lets the entrypoint drop privileges cleanly so SIGTERM from
+# `docker stop` reaches Streamlit directly (no extra shell layer).
+# curl is needed for the healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    gosu \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Install only what's needed
@@ -18,12 +26,16 @@ RUN mkdir -p data logs
 # Copy .env.example as default if no .env is mounted
 RUN cp .env.example .env
 
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 EXPOSE 8501
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
     CMD curl -f http://localhost:8501/_stcore/health || exit 1
 
-ENTRYPOINT ["python", "-m", "streamlit", "run", "src/app.py", \
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["python", "-m", "streamlit", "run", "src/app.py", \
     "--server.port=8501", \
     "--server.address=0.0.0.0", \
     "--server.headless=true"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
     image: ollama/ollama:latest
     container_name: empathysync-ollama
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     entrypoint: ["/bin/sh", "/entrypoint.sh"]
     environment:
-      - OLLAMA_MODEL=${OLLAMA_MODEL}  
+      - OLLAMA_MODEL=${OLLAMA_MODEL}
     volumes:
       - ollama_data:/root/.ollama
       - ./scripts/entrypoint.sh:/entrypoint.sh:ro
@@ -21,12 +21,15 @@ services:
     build: .
     container_name: empathysync-app
     ports:
-      - "8501:8501"
+      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-8501}:8501"
     volumes:
       - ./data:/app/data
       - ./.env:/app/.env:ro
     environment:
       - OLLAMA_HOST=http://ollama:11434
+      # Match your host user: run `id -u` and `id -g` to find these.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
     depends_on:
       ollama:
         condition: service_healthy

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Drop from root to PUID:PGID before starting the app.
+#
+# Without this the container runs as root and writes root-owned files into
+# the bind-mounted ./data and ./logs dirs. Any later non-root run (or the
+# host user trying to edit conversation history) then fails silently on EPERM.
+#
+# Set PUID/PGID in docker-compose.yml or your .env to match your host user:
+#   id -u   # find your PUID
+#   id -g   # find your PGID
+set -e
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if ! getent group "$PGID" >/dev/null 2>&1; then
+    groupadd -g "$PGID" empathysync
+fi
+if ! getent passwd "$PUID" >/dev/null 2>&1; then
+    useradd -u "$PUID" -g "$PGID" -M -s /bin/sh -d /app empathysync
+fi
+
+# Repair ownership on writable paths so files written by a previous
+# root run don't block the non-root user on restart.
+for dir in /app/data /app/logs; do
+    if [ -d "$dir" ]; then
+        find "$dir" -not -uid "$PUID" -print0 2>/dev/null \
+            | xargs -0 -r chown "$PUID:$PGID" 2>/dev/null || true
+    fi
+done
+
+# exec + gosu: no extra shell layer, so SIGTERM from `docker stop`
+# reaches Streamlit directly instead of being swallowed by a wrapper.
+exec gosu "$PUID:$PGID" "$@"


### PR DESCRIPTION
## Summary

Two infrastructure improvements:

**Docker hardening** (from issue #126):
- Adds `docker/entrypoint.sh`: drops from root to `PUID:PGID` before starting Streamlit, repairs bind-mount ownership on restart, uses `gosu` + `exec` so `docker stop` SIGTERM reaches Streamlit directly
- Updates `Dockerfile`: installs `gosu`, copies and uses the entrypoint script, splits `ENTRYPOINT`/`CMD` so the entrypoint can drop privileges before passing the command through
- Updates `docker-compose.yml`: binds to `127.0.0.1` by default (was `0.0.0.0`), adds `PUID`/`PGID` env vars, same localhost binding for Ollama port

**Docs-only CI skip** (from Odysseus pattern):
- Adds a `docs-check` step to `test` and `validate-scenarios` jobs: if all changed files are under `docs/`, end with `.md`, or are `.github/*.md`, expensive steps (install, lint, pytest) are skipped
- Job still reports success so required status checks are never blocked
- `manifesto-guard` always runs regardless - it is fast and security-critical

## Testing

- [ ] `pytest tests/` passes
- [ ] `black --check src/` passes
- [ ] `docker build .` succeeds
- [ ] `docker compose up` starts correctly with default PUID/PGID

Partially closes #126.