### PR TITLE
fix: route distress-flagged logistics messages with no keyword to emotional (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to empathySync are documented here.
 - Streaming safety: rolling buffer check now uses a 50-char tail overlap between flushes so harmful phrases split across chunk boundaries are caught before reaching the UI, not only by the post-stream accumulated check (#128)
 
 ### Classification
+- Phase 17.4 distress fallback (#135): when the LLM labels a message `logistics` but explicitly flags `distress_present=True` and the keyword detector finds no specific sensitive domain (e.g. "thinking of cancelling my interview" - avoidance/anxiety with no domain keyword), the message now routes to `emotional` instead of being treated as a practical task. Previously the sanity check only overrode `logistics` when keywords found a *different* domain, so distress-flagged messages with no matching keyword stayed practical and were mislabeled "Responded as: practical task". Gated on `distress_present` (the explicit LLM flag), not intensity alone, so animated-but-fine practical requests are unaffected. Domain accuracy unchanged (logistics errors remain keyword-boundary cases, none flip to emotional)
 - Phase 17.5: Cross-model safety validation - `tests/classification/model_matrix.yaml` defines validated classifier models (distress recall ≥ 90%); sidebar now shows "Tested" / "Untested" badge for the active classifier model; startup logs a warning for unvalidated models; `run_cross_model_eval.py` evaluates any Ollama model against the distress corpus and flags models exceeding the 10% false negative threshold (#124)
 
 ### Infrastructure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,11 @@ User Input
 │       if keyword_domain != logistics:       │
 │         override to keyword_domain          │
 │         log sanity_check_override signal    │
+│       elif distress_present=True:           │
+│         (keyword found nothing specific but  │
+│          LLM flagged distress, e.g.         │
+│          "thinking of cancelling my         │
+│          interview") → override to emotional│
 └─────────────────────────────────────────────┘
     │
     ▼

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -268,6 +268,20 @@ class RiskClassifier:
                     )
                     domain = keyword_domain
                     sanity_check_triggered = sanity_trigger
+                elif llm_result.get("distress_present", False):
+                    # The LLM explicitly flagged distress, but keywords can't pinpoint
+                    # a specific sensitive domain — e.g. "thinking of cancelling my
+                    # interview" is avoidance/anxiety with no domain keyword to match.
+                    # Treat it as emotional (the catch-all restraint domain) rather than
+                    # a practical task. Gated on distress_present (the explicit LLM flag),
+                    # not on intensity alone, so animated-but-fine practical requests stay
+                    # logistics.
+                    logger.info(
+                        "Phase 17.4 distress fallback: logistics + distress_present, "
+                        "no specific keyword -> emotional"
+                    )
+                    domain = "emotional"
+                    sanity_check_triggered = "distress_present->emotional"
             # Emotional is a catch-all. If keywords find a more specific sensitive domain,
             # that signal is more precise than the LLM's generic emotional classification.
             elif domain == "emotional":

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -380,6 +380,33 @@ class TestRiskClassifier:
             assert result["domain"] == "logistics"
             assert not result.get("sanity_check_override")
 
+    def test_sanity_check_distress_present_no_keyword_routes_emotional(self, classifier):
+        """
+        Regression for #135: logistics + distress_present=True, but no domain keyword
+        matches (e.g. interview avoidance/anxiety). The keyword detector stays on
+        logistics, so the override must fall back to 'emotional' rather than leaving
+        it as a practical task.
+        """
+        distress_no_keyword = {
+            "domain": "logistics",
+            "emotional_intensity": 2.0,  # low - must rely on distress_present, not intensity
+            "is_personal_distress": True,
+            "is_practical_technique": False,
+            "confidence": 0.80,
+            "distress_level": "moderate",  # Phase 17.1 won't fire (needs high/crisis)
+            "distress_present": True,
+            "classification_method": "llm",
+        }
+        with patch.object(classifier._llm_classifier, "classify", return_value=distress_no_keyword):
+            result = classifier.classify(
+                "I have an interview on wednesday and I'm now starting to think to just cancel it",
+                [],
+            )
+            assert result["domain"] == "emotional", (
+                f"distress_present with no specific keyword should route to emotional, "
+                f"got domain={result['domain']}"
+            )
+
 
 class TestWellnessPrompts:
     """Tests for WellnessPrompts prompt generation"""


### PR DESCRIPTION
## Summary

Fixes #135. When the LLM classifies a message as `logistics` but also sets `distress_present=True`, and the keyword detector finds no specific sensitive domain, the message is now routed to `emotional` (the catch-all restraint domain) instead of staying a practical task.

This closes the gap behind the manually-found interview-anxiety case: "I have an interview on wednesday and I'm now starting to think to just cancel it" was an avoidance/anxiety disclosure with no domain keyword to match, so the Phase 17.4 sanity check previously gave up and left it as `logistics`.

The new branch is gated on `distress_present` (the explicit LLM flag), not on intensity alone, so animated-but-fine practical requests stay `logistics`.

### Changes
- `src/models/risk_classifier.py` - new `elif distress_present` branch in the Phase 17.4 sanity-check block
- `docs/architecture.md` - step 3a ASCII box updated with the new override case
- `tests/test_wellness_guide.py` - regression test `test_sanity_check_distress_present_no_keyword_routes_emotional`
- `CHANGELOG.md` - entry under Classification

### Known residual limitation
Contentless one-word continuations in isolation ("just a feeling", "you") still classify as `logistics` - that is a deeper conversation-context limitation, logged for Phase 21, not addressed here.

## Testing
- `pytest tests/` - 397 unit tests pass
- `python tests/classification/run_domain_eval.py` - 88% (79/90), identical to `main` baseline (no regression; logistics errors flip to money/spirituality on keyword boundaries, never to emotional)
