### PR TITLE
ci: skip PR description validation for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   validate-description:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR description


### PR DESCRIPTION
## Summary

Dependabot's auto-generated PR body contains only the dependency changelog and commit list - it has no `## Summary` or `## Testing` sections and cannot fill the repo's PR template. As a result, the `validate-description` job in `pr-validation.yml` failed on every dependency bump (most recently #139, which had to be unblocked by hand-editing the PR body).

This adds `if: github.actor != 'dependabot[bot]'` to the `validate-description` job so it is skipped for Dependabot PRs. The template requirement still applies to all human-authored PRs.

`validate-description` is not a required status check in the `main` ruleset (the required checks are `test (3.9-3.12)` and `manifesto-guard`), so skipping the job for Dependabot does not leave a phantom pending required check.

## Testing

No application code changed - this is a CI workflow gate only. Verified the required-checks set via the repo ruleset API before making the change to confirm `validate-description` is not required. The next Dependabot PR will show the job as skipped rather than failed.