### PR TITLE
feat: one-time notice that local data is stored unencrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to empathySync are documented here.
 ## [Unreleased]
 
 ### Security
+- Encryption-at-rest notice: a one-time UI warning now states that conversations are stored unencrypted and points to `THREAT_MODEL.md`. `THREAT_MODEL.md` already documents "no encryption at rest" as a known gap, but a user on a shared machine will not read it before their history is written to disk - this surfaces that honesty in the app itself, matching the transparency principle. Shown only when `STORE_CONVERSATIONS` is on; dismissing it writes a marker under the (git-ignored) data dir so it never nags again
 - Prompt injection: classification prompt now explicitly instructs the model not to follow instructions inside the `<user_message>` boundary, reducing risk on weaker models (#127)
 - Streaming safety: rolling buffer check now uses a 50-char tail overlap between flushes so harmful phrases split across chunk boundaries are caught before reaching the UI, not only by the post-stream accumulated check (#128)
 

--- a/src/app.py
+++ b/src/app.py
@@ -40,6 +40,32 @@ apply_page_config()
 apply_custom_css()
 
 
+def display_encryption_notice():
+    """One-time notice that local data is stored unencrypted.
+
+    THREAT_MODEL.md is explicit that there is no encryption at rest, but a user
+    running on a shared machine will not read it before their conversation
+    history is written to disk. This surfaces that honesty in the UI itself,
+    matching the transparency philosophy used elsewhere. Only shown when
+    persistence is on; dismissing it writes a marker so it never nags again.
+    """
+    if not settings.STORE_CONVERSATIONS:
+        return
+    ack_marker = settings.DATA_DIR / ".encryption_notice_ack"
+    if ack_marker.exists():
+        return
+    st.warning(
+        f"Conversations are stored **unencrypted** at `{settings.DATA_DIR}`. "
+        "On a shared machine, enable full-disk encryption. See `THREAT_MODEL.md`."
+    )
+    if st.button("Understood - don't show this again"):
+        try:
+            ack_marker.touch()
+        except OSError:
+            pass  # Non-critical: the notice simply shows again next launch
+        st.rerun()
+
+
 def main():
     """Main application function"""
 
@@ -115,6 +141,9 @@ def main():
             except Exception:
                 pass  # Non-critical: pruning can retry next session
         st.session_state.data_pruned = True
+
+    # One-time notice: local data is stored unencrypted at rest (THREAT_MODEL.md)
+    display_encryption_notice()
 
     # Phase 11: Check device lock status (enables read-only mode if locked by other)
     display_lock_warning()


### PR DESCRIPTION
## Summary

Adds a one-time UI notice that conversations are stored **unencrypted** at rest, pointing users to `THREAT_MODEL.md`.

`THREAT_MODEL.md` already lists "no encryption at rest" as a known gap, but a user running on a shared machine will not have read it before their conversation history is written to disk. This surfaces that honesty in the app itself, matching empathySync's transparency principle (every policy action is logged and explained).

Behaviour:
- `display_encryption_notice()` is called once per session in `main()`, right after the data-pruning block.
- Shown **only** when `STORE_CONVERSATIONS` is enabled - no notice when nothing is persisted.
- Dismissing it (`Understood - don't show this again`) touches a `.encryption_notice_ack` marker under `settings.DATA_DIR`. Because `data/` is git-ignored, the marker is local-only and never committed, so this is true first-launch behaviour per machine.
- Marker write failures are swallowed (non-critical): the notice simply reappears next launch rather than erroring.

No classification, pipeline, storage-schema, or dependency changes.

## Testing

- `black src/app.py` - passed (also via pre-commit hook on commit)
- `flake8` with the project's pre-commit config (`--max-line-length=100`, project ignore list) - clean
- `pytest tests/ -q -m "not conversation"` - **1053 passed**, 20 conversation-tier deselected (need Ollama; this change does not affect them). Coverage gate met (64.5%).
- Domain eval not run - no classification change.