### PR TITLE
chore: gitignore .claude/ local tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code local tooling (settings, local permission state, skills)
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore`. The directory holds machine-local Claude Code tooling - `settings.local.json` (per-machine permission grants), `settings.json`, and local skills - none of which belongs in the repo. It had no `.gitignore` entry, so it surfaced as untracked in every `git status`. This ignores the whole directory.

No code or behaviour change.

## Testing

Not applicable - `.gitignore`-only change. Verified `git check-ignore` now matches `.claude/settings.json`, `.claude/settings.local.json`, and the skills files, and that `git status` is otherwise clean.