### PR TITLE
fix: make encryption-at-rest notice a quiet caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to empathySync are documented here.
 ## [Unreleased]
 
 ### Security
-- Encryption-at-rest notice: a one-time UI warning now states that conversations are stored unencrypted and points to `THREAT_MODEL.md`. `THREAT_MODEL.md` already documents "no encryption at rest" as a known gap, but a user on a shared machine will not read it before their history is written to disk - this surfaces that honesty in the app itself, matching the transparency principle. Shown only when `STORE_CONVERSATIONS` is on; dismissing it writes a marker under the (git-ignored) data dir so it never nags again
+- Encryption-at-rest notice: a one-time, low-key UI note (small caption, not an alert banner) states that conversations are stored unencrypted and points to `THREAT_MODEL.md`. `THREAT_MODEL.md` already documents "no encryption at rest" as a known gap, but a user on a shared machine will not read it before their history is written to disk - this surfaces that honesty in the app itself, matching the transparency principle. Shown only when `STORE_CONVERSATIONS` is on; dismissing it writes a marker under the (git-ignored) data dir so it never nags again
 - Prompt injection: classification prompt now explicitly instructs the model not to follow instructions inside the `<user_message>` boundary, reducing risk on weaker models (#127)
 - Streaming safety: rolling buffer check now uses a 50-char tail overlap between flushes so harmful phrases split across chunk boundaries are caught before reaching the UI, not only by the post-stream accumulated check (#128)
 

--- a/src/app.py
+++ b/src/app.py
@@ -54,7 +54,7 @@ def display_encryption_notice():
     ack_marker = settings.DATA_DIR / ".encryption_notice_ack"
     if ack_marker.exists():
         return
-    st.warning(
+    st.caption(
         f"Conversations are stored **unencrypted** at `{settings.DATA_DIR}`. "
         "On a shared machine, enable full-disk encryption. See `THREAT_MODEL.md`."
     )


### PR DESCRIPTION
## Summary

Follow-up to #141. The unencrypted-at-rest notice used `st.warning`, which renders a full amber alert banner with a warning icon - visually louder than the passive, one-time disclosure warrants. This switches it to `st.caption` (small grey text) so it stays visible and honest but no longer reads as an alarm.

No behaviour change: the `STORE_CONVERSATIONS` gate, the dismiss button, and the one-time `.encryption_notice_ack` marker are all unchanged. Only the widget used to render the line changed (`st.warning` -> `st.caption`).

Because #141 is still under `[Unreleased]`, the changelog entry is corrected in place (it previously called this "a one-time UI warning") rather than adding a separate follow-up line - the release notes should describe the final form, not the intermediate one.

## Testing

- `black src/app.py` - passed (also via pre-commit on commit)
- `flake8` with the project pre-commit config - clean
- `pytest tests/ -q -m "not conversation"` - **1053 passed**, 20 conversation-tier deselected. No test asserts on the notice widget, so none needed updating.