### PR TITLE
release: v1.11.0 - Operational Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to empathySync are documented here.
 
-## [Unreleased]
+## v1.11.0 (2026-07-02) - Operational Hardening
 
 ### Security
 - Encryption-at-rest notice: a one-time, low-key UI note (small caption, not an alert banner) states that conversations are stored unencrypted and points to `THREAT_MODEL.md`. `THREAT_MODEL.md` already documents "no encryption at rest" as a known gap, but a user on a shared machine will not read it before their history is written to disk - this surfaces that honesty in the app itself, matching the transparency principle. Shown only when `STORE_CONVERSATIONS` is on; dismissing it writes a marker under the (git-ignored) data dir so it never nags again

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 *Most chatbots want you to keep talking.*
 *This one wants you to leave and go live your life.*
 
-[![v1.10.1](https://img.shields.io/badge/release-v1.10.1-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.10.1)
+[![v1.11.0](https://img.shields.io/badge/release-v1.11.0-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.11.0)
 [![CI](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml/badge.svg)](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Local-First](https://img.shields.io/badge/Privacy-Local--First-blue.svg)](#)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2620,18 +2620,24 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 
 ---
 
-## Next Up: v1.11.0 - Operational Hardening (planned, post-v1.10.1)
+## v1.11.0 - Operational Hardening (released 2026-07-02)
 
 Contributor-experience and operational improvements identified from reviewing mature
 self-hosted OSS projects. None are bugs in v1.10.1; they harden the project as the
 contributor base grows.
 
-- [ ] Docker entrypoint hardening: PUID/PGID permission handling, CUDA detection, SIGTERM signal forwarding
-- [ ] Issue templates (`.github/`) requesting install method, OS, Ollama version, and model
-- [ ] PR-description validation GitHub Action (summary present, type-of-change, testing notes)
+- [x] Docker entrypoint hardening: PUID/PGID permission handling, CUDA detection, SIGTERM signal forwarding
+- [x] Issue templates (`.github/`) requesting install method, OS, Ollama version, and model
+- [x] PR-description validation GitHub Action (summary present, type-of-change, testing notes)
 - [ ] `dev`/`main` branch model: PRs target `dev`, `main` stays curated
 - [ ] THREAT_MODEL.md follow-through: address documented gaps (filesystem/shell sandboxing options, optional encryption at rest)
 - [ ] Clean-machine install test before public demos: verify the "runs on your laptop" path end to end
+
+Shipped alongside the operational items: THREAT_MODEL.md engineering-controls table and a
+one-time in-app encryption-at-rest notice (transparency, not encryption itself), plus the
+Phase 17.4 distress fallback and Phase 17.5 cross-model safety validation. The three
+unchecked items above are deferred to a later release - optional encryption at rest and the
+`dev`/`main` split in particular remain open.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "empathysync"
-version = "1.10.1"
+version = "1.11.0"
 description = "A local-first AI assistant that provides full help for practical tasks while applying restraint on sensitive topics"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -17,7 +17,7 @@ class Settings:
 
     # Application
     APP_NAME: str = "empathySync"
-    APP_VERSION: str = "1.10.1"
+    APP_VERSION: str = "1.11.0"
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary

Release v1.11.0. Renames the `[Unreleased]` CHANGELOG section to `## v1.11.0 (2026-07-02) - Operational Hardening` and bumps the version across all four version-bearing files (`pyproject.toml`, `src/config/settings.py`, `README.md` badge, `CHANGELOG.md`).

Contents of the release (already merged to main under `[Unreleased]`): Docker entrypoint hardening (PUID/PGID via gosu), PR-description validation action, bug-report template, THREAT_MODEL.md engineering-controls table, one-time in-app encryption-at-rest notice, Phase 17.4 distress fallback, Phase 17.5 cross-model safety validation, domain-corpus broadening (90 -> 94), and doc/count reconciliation.

ROADMAP updated: the three shipped operational-hardening items are checked; `dev`/`main` branch model, optional encryption at rest, and the clean-machine install test are honestly marked deferred (not shipped in this release).

## Testing

- `python scripts/check_version.py` - all four files consistent at 1.11.0
- `pytest tests/ -q -m "not conversation"` - 1053 passed, 20 deselected