### PR TITLE
chore: remove dead config (PostgreSQL, ENABLE_ANALYTICS, unused HOST/PORT) and sync docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,23 +14,6 @@ OLLAMA_TEMPERATURE=0.7
 # OLLAMA_SEED=42
 
 # ===================
-# Optional: Database
-# ===================
-# Only needed if you want PostgreSQL storage (not required for basic usage)
-# DB_HOST=localhost
-# DB_PORT=5432
-# DB_NAME=empathysync
-# DB_USER=
-# DB_PASSWORD=
-
-# ===================
-# Security
-# ===================
-# Secret key for session signing. Generate a random value for production:
-#   python -c "import secrets; print(secrets.token_urlsafe(32))"
-# SECRET_KEY=change-me-to-a-random-string
-
-# ===================
 # Docker
 # ===================
 # Host address the app binds to inside the container.
@@ -103,10 +86,3 @@ ENABLE_DEVICE_LOCK=false
 # If the other device crashes or loses power, the lock expires after this timeout
 # Default: 300 (5 minutes)
 LOCK_STALE_TIMEOUT=300
-
-# ===================
-# Session Settings
-# ===================
-# Minutes of inactivity before a session is considered timed out
-# Default: 30
-# SESSION_TIMEOUT_MINUTES=30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to empathySync are documented here.
 
+## [Unreleased]
+
+### Removed
+- Dead configuration that was never read by any code and misled contributors about
+  the architecture: PostgreSQL settings (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`,
+  `DB_PASSWORD`, the `database_url` property, and the DB branch of `validate_config()`)
+  - no PostgreSQL driver has ever been a dependency and both storage backends are
+  JSON/SQLite; `ENABLE_ANALYTICS` - unused, and its existence contradicted the
+  no-telemetry principle; unused `HOST`/`PORT` fields (`src/config/settings.py`);
+  the empty `src/prompts/blessed_mode_prompts.py`
+- `.env.example` entries for variables that no code reads: the PostgreSQL block,
+  `SECRET_KEY` (there is no session signing anywhere - the "generate for production"
+  instruction was actively misleading), and `SESSION_TIMEOUT_MINUTES`
+- Stale `docs/setup.md` sections: PostgreSQL configuration and troubleshooting for
+  `psycopg2-binary` and `sentence-transformers`, neither of which is a dependency
+
+### Documentation
+- Removed the "Optional PostgreSQL" env var section from `CLAUDE.md`
+- Corrected unit test count 1052 -> 1053 (`CLAUDE.md`, `docs/architecture.md`),
+  verified against a full `pytest -m "not conversation"` run
+
 ## v1.11.0 (2026-07-02) - Operational Hardening
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ empathysync --log-level DEBUG            # Override log verbosity
 docker compose up
 
 # Tests
-pytest tests/                            # Full suite (1052 unit + 20 conversation)
+pytest tests/                            # Full suite (1053 unit + 20 conversation)
 pytest tests/ --cov=src                  # With coverage
 pytest tests/ -m "not conversation"      # Skip Ollama-dependent tests
 python tests/classification/run_domain_eval.py          # Domain accuracy eval
@@ -64,9 +64,6 @@ See `.env.example` for full documentation and defaults.
 - `USE_SQLITE` — SQLite backend instead of JSON (default: `false`)
 - `ENABLE_DEVICE_LOCK` — Heartbeat lock for multi-device sync (default: `false`)
 - `LOCK_STALE_TIMEOUT` — Seconds until a stale lock expires (default: `300`)
-
-**Optional PostgreSQL** (all or none): `DB_HOST`, `DB_PORT`, `DB_NAME`,
-`DB_USER`, `DB_PASSWORD`
 
 **Docker only:**
 - `APP_BIND` — Host address to bind to (default: `127.0.0.1`; set `0.0.0.0` for LAN access)
@@ -107,7 +104,7 @@ tests/
     └── run_domain_eval.py          # Per-domain accuracy report
 ```
 
-Current counts: ~1052 unit tests, 20 conversation quality scenarios.
+Current counts: ~1053 unit tests, 20 conversation quality scenarios.
 
 Pre-existing known failure: `stress_test_001` conversation tier is
 non-deterministic (LLM output varies); the structural tier always passes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -599,7 +599,7 @@ empathySync/
 │
 ├── data/                        # Local user data (JSON/SQLite)
 ├── logs/                        # Application logs
-├── tests/                       # Pytest test suite (1052 unit + 20 conversation quality)
+├── tests/                       # Pytest test suite (1053 unit + 20 conversation quality)
 └── docs/                        # Documentation
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -66,14 +66,6 @@ venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-### Troubleshooting Dependencies
-
-**psycopg2-binary fails to install:**
-PostgreSQL is optional. You can comment out the database lines in requirements.txt if you only want local JSON storage.
-
-**sentence-transformers takes long to install:**
-This is normal - it downloads model files. Be patient.
-
 ## Step 5: Configure Environment
 
 ```bash
@@ -112,18 +104,6 @@ CONVERSATION_RETENTION_DAYS=30
 # Intelligent classification (Phase 9)
 # Uses LLM for context-aware domain detection
 LLM_CLASSIFICATION_ENABLED=true
-```
-
-### PostgreSQL (Optional)
-
-Only configure if you want database storage instead of local JSON files:
-
-```env
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=empathysync
-DB_USER=your_username
-DB_PASSWORD=your_password
 ```
 
 ## Step 6: Verify Installation

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -21,24 +21,6 @@ class Settings:
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 
-    # Server
-    HOST: str = os.getenv("HOST", "127.0.0.1")
-    PORT: int = int(os.getenv("STREAMLIT_SERVER_PORT", "8501"))
-
-    # Database (leveraging PostgreSQL)
-    DB_HOST: str = os.getenv("DB_HOST", "")
-    DB_PORT: Optional[int] = int(os.getenv("DB_PORT", "5432")) if os.getenv("DB_PORT") else None
-    DB_NAME: str = os.getenv("DB_NAME", "")
-    DB_USER: str = os.getenv("DB_USER", "")
-    DB_PASSWORD: str = os.getenv("DB_PASSWORD", "")
-
-    @property
-    def database_url(self) -> Optional[str]:
-        """Construct database URL from components"""
-        if not all([self.DB_HOST, self.DB_PORT, self.DB_NAME, self.DB_USER, self.DB_PASSWORD]):
-            return None
-        return f"postgresql://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
-
     # Ollama Configuration
     OLLAMA_HOST: str = os.getenv("OLLAMA_HOST", "")
     OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "")
@@ -76,7 +58,6 @@ class Settings:
     LOCK_STALE_TIMEOUT: int = int(os.getenv("LOCK_STALE_TIMEOUT", "300"))
 
     # Privacy & Security
-    ENABLE_ANALYTICS: bool = os.getenv("ENABLE_ANALYTICS", "false").lower() == "true"
     STORE_CONVERSATIONS: bool = os.getenv("STORE_CONVERSATIONS", "true").lower() == "true"
     CONVERSATION_RETENTION_DAYS: int = int(os.getenv("CONVERSATION_RETENTION_DAYS", "30"))
 
@@ -108,17 +89,6 @@ class Settings:
             missing.append("OLLAMA_HOST (must start with http:// or https://)")
         if not self.OLLAMA_MODEL:
             missing.append("OLLAMA_MODEL")
-
-        # Database validation only if any DB setting is provided
-        if any([self.DB_HOST, self.DB_NAME, self.DB_USER, self.DB_PASSWORD]):
-            if not self.DB_HOST:
-                missing.append("DB_HOST")
-            if not self.DB_NAME:
-                missing.append("DB_NAME")
-            if not self.DB_USER:
-                missing.append("DB_USER")
-            if not self.DB_PASSWORD:
-                missing.append("DB_PASSWORD")
 
         return missing
 


### PR DESCRIPTION
## Summary

Removes configuration that no code has ever read, and syncs the docs that referenced it. Dead config actively misleads contributors about the architecture - the PostgreSQL block implied a third storage backend that has never existed (no driver in any dependency list; both backends are JSON/SQLite), and `ENABLE_ANALYTICS` contradicted the no-telemetry principle just by existing.

- `src/config/settings.py`: removed `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD`, the `database_url` property, the DB branch of `validate_config()`, `ENABLE_ANALYTICS`, and unused `HOST`/`PORT`
- Deleted `src/prompts/blessed_mode_prompts.py` (zero-byte file, never imported)
- `.env.example`: removed the PostgreSQL block, `SECRET_KEY` (no session signing exists anywhere - the "generate for production" instruction was misleading), and `SESSION_TIMEOUT_MINUTES` (never read)
- `docs/setup.md`: removed the PostgreSQL section and troubleshooting entries for `psycopg2-binary` and `sentence-transformers`, neither of which is a dependency
- `CLAUDE.md`: removed the "Optional PostgreSQL" env var section
- Corrected unit test count 1052 -> 1053 (`CLAUDE.md`, `docs/architecture.md`)
- CHANGELOG entry under `[Unreleased]`

## Type of change

- [x] Chore (cleanup, no functional change)

## Testing

- `pytest tests/ -m "not conversation"`: **1053 passed**, 20 deselected (tests mock `validate_config`, no test referenced any removed field - verified by grep before removal)
- `black --check` and `flake8` (hook config): clean
- Domain eval (`run_domain_eval.py`, mistral:7b-instruct): 80/94 (85%) vs documented 81/94 (86%). The delta is one spirituality boundary example wobbling run-to-run; all 14 misses are documented boundary cases and this PR touches no classification path (removed fields were referenced nowhere).