### PR TITLE
fix: count turn limits per domain, not per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to empathySync are documented here.
   meta-question list, so a plain greeting got "Not something I track." - removed;
   genuine self-evaluation phrasings ("rate yourself", "how did you do") still deflect.
   Six regression tests added
+- Turn limits are now counted per domain (`src/models/ai_wellness_guide.py`). The
+  check compared the *global* session turn count against the *current domain's*
+  limit, so 14 turns of coding followed by a first health question tripped health's
+  limit (15) on that first health turn - the user was told "we've been talking about
+  this for a while" about a topic they raised one message ago. Each domain now has
+  its own counter; limits fire after N turns *in that domain*. Within-domain
+  enforcement is unchanged. Four regression tests added;
+  `docs/architecture.md` step 6 updated to state the per-domain semantics
 
 ### Removed
 - Dead configuration that was never read by any code and misled contributors about

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,8 @@ User Input
     ▼
 ┌─────────────────────────────────────────────┐
 │  6. TURN LIMIT CHECK                        │
-│     Each domain has max turns (configurable │
+│     Turns counted PER DOMAIN and compared   │
+│     to that domain's limit (configurable    │
 │     in system_defaults.yaml):               │
 │     logistics:30, money:15, health:15,      │
 │     relationships:15, spirituality:10       │

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -133,6 +133,9 @@ class WellnessGuide:
         # Session state tracking
         self.session_turn_count = 0
         self.session_domains = []
+        # Turn limits are per domain: a long practical session must not make
+        # the first turn in a sensitive domain trip that domain's limit.
+        self.domain_turn_counts = {}
         self.session_max_risk = 0.0
         self.last_risk_assessment = None
         self.last_policy_action = None
@@ -310,6 +313,7 @@ class WellnessGuide:
         domain = risk_assessment["domain"]
         if domain not in self.session_domains:
             self.session_domains.append(domain)
+        self.domain_turn_counts[domain] = self.domain_turn_counts.get(domain, 0) + 1
         self.session_max_risk = max(self.session_max_risk, risk_assessment["risk_weight"])
 
         # Log context inheritance if it occurred
@@ -481,9 +485,11 @@ class WellnessGuide:
             prepared.domain = domain
             return prepared
 
-        # 4) Check turn limits by risk level
+        # 4) Check turn limits by risk level - counted per domain, not per
+        # session, so an established practical session doesn't make the first
+        # turn in a sensitive domain trip that domain's limit.
         turn_limit = TURN_LIMITS.get(domain, 15)
-        if self.session_turn_count >= turn_limit:
+        if self.domain_turn_counts.get(domain, 0) >= turn_limit:
             self._log_policy(
                 "turn_limit_reached",
                 domain,
@@ -1683,6 +1689,7 @@ class WellnessGuide:
         """Reset session state for new conversation."""
         self.session_turn_count = 0
         self.session_domains = []
+        self.domain_turn_counts = {}
         self.session_max_risk = 0.0
         self.last_risk_assessment = None
         self.last_policy_action = None

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -3600,3 +3600,80 @@ class TestVoiceTuning:
         risk = {"risk_weight": 1.0}
         result = guide._process_response(long_response, "test", risk, is_practical=True)
         assert len(result.split()) >= 190  # Should keep most words
+
+
+class TestPerDomainTurnLimits:
+    """Turn limits count turns in the domain, not turns in the session.
+
+    Regression tests for the 2026-07-03 fix: the check compared the global
+    session_turn_count against the current domain's limit, so a long practical
+    session made the first turn in a sensitive domain trip that domain's limit.
+    """
+
+    @pytest.fixture
+    def mock_settings(self):
+        with patch("models.ai_wellness_guide.settings") as mock:
+            mock.OLLAMA_HOST = "http://localhost:11434"
+            mock.OLLAMA_MODEL = "llama2"
+            mock.OLLAMA_TEMPERATURE = 0.7
+            yield mock
+
+    @pytest.fixture
+    def guide(self, mock_settings):
+        from models.ai_wellness_guide import WellnessGuide
+
+        return WellnessGuide()
+
+    def _assessment(self, domain):
+        """Fixed keyword-style assessment so tests never touch Ollama."""
+        return {
+            "domain": domain,
+            "emotional_intensity": 2.0,
+            "emotional_weight": "low_weight",
+            "emotional_weight_score": 0.0,
+            "dependency_risk": 0.0,
+            "risk_weight": 2.0,
+            "classification_method": "keyword",
+        }
+
+    def test_first_turn_in_new_domain_does_not_trip_limit(self, guide):
+        """14 practical turns then the first health turn: health's limit (15) must not fire."""
+        guide.session_turn_count = 14
+        guide.domain_turn_counts = {"logistics": 14}
+        guide.primary_domain = "logistics"
+        with patch.object(
+            guide.risk_classifier, "classify", return_value=self._assessment("health")
+        ):
+            prepared = guide._prepare_response("health question")
+        assert guide.domain_turn_counts["health"] == 1
+        assert prepared.early_return is None
+        assert prepared.full_prompt
+
+    def test_domain_limit_still_enforced_within_domain(self, guide):
+        """The 10th spirituality turn trips spirituality's limit (10)."""
+        guide.domain_turn_counts = {"spirituality": 9}
+        with patch.object(
+            guide.risk_classifier, "classify", return_value=self._assessment("spirituality")
+        ):
+            prepared = guide._prepare_response("about my faith")
+        assert prepared.early_return is not None
+        assert guide.last_policy_action is not None
+        assert guide.last_policy_action["type"] == "turn_limit_reached"
+
+    def test_counts_accumulate_per_domain(self, guide):
+        """Each turn increments only the assessed domain's counter."""
+        with patch.object(
+            guide.risk_classifier, "classify", return_value=self._assessment("logistics")
+        ):
+            guide._prepare_response("write an email")
+            guide._prepare_response("now a cover letter")
+        with patch.object(
+            guide.risk_classifier, "classify", return_value=self._assessment("money")
+        ):
+            guide._prepare_response("budget question")
+        assert guide.domain_turn_counts == {"logistics": 2, "money": 1}
+
+    def test_reset_session_clears_domain_counts(self, guide):
+        guide.domain_turn_counts = {"logistics": 5, "health": 2}
+        guide.reset_session()
+        assert guide.domain_turn_counts == {}


### PR DESCRIPTION
## Summary

Fixes the turn-limit semantics found in the 2026-07-03 project review. The check in `_prepare_response` compared the **global** session turn count against the **current domain's** limit:

```python
turn_limit = TURN_LIMITS.get(domain, 15)
if self.session_turn_count >= turn_limit:
```

So 14 turns of coding followed by a first health question tripped health's limit (15) on that first health turn - the user was told "we've been talking about this for a while" about a topic they raised one message ago. `docs/architecture.md` already described the intent as "each domain has max turns"; the implementation now matches it.

- New `domain_turn_counts` dict on `WellnessGuide`, incremented alongside the existing session metrics once the domain is final (after context adjustment and domain stability)
- Limit check compares the domain's own count; within-domain enforcement is unchanged (the Nth turn in a domain still trips that domain's limit)
- Reset in `reset_session()`
- `docs/architecture.md` step 6 box updated to state the per-domain counting

## Type of change

- [x] Bug fix

## Testing

- Four regression tests in `tests/test_wellness_guide.py` (`TestPerDomainTurnLimits`): first turn in a new domain after a long practical run does not trip the limit; the 10th spirituality turn still trips spirituality's limit; counters accumulate per domain; `reset_session` clears them. Classifier is mocked so the tests never touch Ollama.
- Full suite: `pytest tests/ -m "not conversation"` - **1057 passed** (1053 + 4 new), 20 deselected; no existing test relied on the old global-counter semantics
- Domain eval (mistral:7b-instruct): **81/94 (86%)** - matches baseline exactly
- `black` + `flake8` pre-commit hooks: passed