### PR TITLE
chore: read tunables at call time, drop dir() idiom, correct mid-stream check docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to empathySync are documented here.
 ## [Unreleased]
 
 ### Refactored
+- Config values are now read at call time instead of being baked into module-level
+  constants at import time (`MAX_INPUT_LENGTH`, `TURN_LIMITS`,
+  `POST_CRISIS_CLEAR_AFTER`, `IDENTITY_REMINDER_FREQUENCY` in
+  `ai_wellness_guide.py`; `_CONFIDENCE_THRESHOLD` in `conversation_session.py`).
+  Previously `reload_scenarios()` (hot reload) silently never refreshed these five
+  values, undermining the "tune YAML without touching Python" contract. Four
+  near-identical `_load_*()` loader functions removed; two tests pin the
+  call-time-read behavior. Also replaced the fragile `"prepared" in dir()` idiom in
+  both `generate_response` exception handlers with an explicit `prepared = None`
+
+### Documentation (safety-claim accuracy)
+- The mid-stream streaming buffer check was described as intercepting "harmful
+  content", overstating what it detects: `_contains_harmful_content()` matches the
+  manipulative-voice patterns from `safe_alternatives.yaml` (false intimacy,
+  dependency-encouraging phrasing), not dangerous-instruction content - blocking
+  harmful requests is the input-side layers' job. `THREAT_MODEL.md` engineering-
+  controls row, `CLAUDE.md` key-patterns entry, and the `docs/architecture.md`
+  streaming box now say exactly that. Scanning *output* for dangerous content with
+  the Phase 21 safety model is noted as a stretch goal in the roadmap
+
+### Refactored (session pipelines)
 - Deduplicated the ConversationSession pipelines (`src/models/conversation_session.py`,
   -113 lines). `process_message` and `process_message_stream`/`finalize_stream`
   each carried a full copy of the pre-LLM steps (cooldown, first-turn intent,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,10 @@ field in the prompt.
 
 **Mid-Stream Safety Buffer** (`src/models/ai_wellness_guide.py`): A 200-char
 rolling buffer accumulates tokens before yielding to the UI. `_contains_harmful_content()`
-runs on each flush — harmful content is intercepted before it reaches the
-screen, not only after the full response.
+runs on each flush — it matches the manipulative-voice patterns from
+`safe_alternatives.yaml` (false intimacy, dependency-encouraging phrasing), so
+voice violations are intercepted before they reach the screen. It is not a
+dangerous-content scanner; blocking harmful requests is the input-side layers' job.
 
 **emotional→specific override** (`src/models/risk_classifier.py`): When the
 LLM classifies a message as `emotional` (catch-all) but the keyword detector

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -52,7 +52,7 @@ not a refactor. The prose above explains *why* each control exists; this maps
 |---------|-------------|-------|
 | No external calls | Only outbound traffic is to the local `OLLAMA_HOST` | `src/models/llm_classifier.py`, `src/utils/http_client.py` |
 | Prompt-injection boundary | User message wrapped in `<user_message>` tags, truncated to 5000 chars | `src/models/llm_classifier.py` |
-| Mid-stream harmful-output check | 200-char rolling buffer scanned before tokens reach the UI | `src/models/ai_wellness_guide.py` |
+| Mid-stream output voice check | 200-char rolling buffer scanned for manipulative-language patterns (false intimacy, dependency-encouraging phrasing, `safe_alternatives.yaml`) before tokens reach the UI. Not a dangerous-content scanner - blocking harmful *requests* is the input-side layers' job | `src/models/ai_wellness_guide.py` |
 | No SQL injection via dynamic names | Table and column whitelists; all values parameterized | `src/utils/storage_backend.py` |
 | Write gate | `_ensure_write_allowed()` at the top of every write method | `src/utils/write_gate.py`, `src/utils/storage_backend.py` |
 | Atomic writes | `mkstemp` + `fsync` + `os.replace` (no torn files on crash) | `src/utils/storage_backend.py` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,8 +207,11 @@ User Input
 │     Tokens accumulated in 200-char rolling  │
 │     buffer before yielding to UI            │
 │     _contains_harmful_content() runs on     │
-│     each buffer flush (mid-stream check)    │
-│     Harmful content intercepted before it   │
+│     each buffer flush (mid-stream check):   │
+│     matches manipulative-voice patterns     │
+│     (safe_alternatives.yaml), NOT dangerous │
+│     content - that is the input layers' job │
+│     Voice violation intercepted before it   │
 │     reaches the UI - safe alternative       │
 │     response substituted immediately        │
 └─────────────────────────────────────────────┘

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -21,23 +21,6 @@ from models.ollama_client import OllamaClient
 logger = logging.getLogger(__name__)
 
 
-def _load_max_input_length() -> int:
-    """Load max input length from system_defaults.yaml, fallback to 5000."""
-    try:
-        from utils.scenario_loader import get_scenario_loader
-
-        loader = get_scenario_loader()
-        defaults = loader.get_system_defaults()
-        return int(defaults.get("ollama", {}).get("max_input_length", 5000))
-    except Exception:
-        return 5000
-
-
-# Maximum allowed input length in characters. Prevents OOM on Ollama
-# and ensures classification latency stays bounded.
-MAX_INPUT_LENGTH = _load_max_input_length()
-
-
 @dataclass
 class PreparedResponse:
     """Result of the pre-LLM pipeline in generate_response().
@@ -54,8 +37,9 @@ class PreparedResponse:
     is_likely_practical: bool = False
 
 
-# Session limits by risk level — loaded from system_defaults.yaml if available,
-# otherwise uses these hardcoded defaults.
+# Session limits by risk level — YAML overrides from system_defaults.yaml are
+# merged over these in _get_turn_limit(), read at call time so that
+# reload_scenarios() picks up edits without a restart.
 _DEFAULT_TURN_LIMITS = {
     "logistics": 30,
     "money": 15,
@@ -65,54 +49,6 @@ _DEFAULT_TURN_LIMITS = {
     "crisis": 1,
     "harmful": 1,
 }
-
-
-def _load_turn_limits():
-    """Load turn limits from config, falling back to hardcoded defaults."""
-    try:
-        from utils.scenario_loader import get_scenario_loader
-
-        loader = get_scenario_loader()
-        configured = loader.get_default("session", "turn_limits", fallback=None)
-        if configured:
-            return {**_DEFAULT_TURN_LIMITS, **configured}
-    except Exception:
-        pass
-    return _DEFAULT_TURN_LIMITS
-
-
-TURN_LIMITS = _load_turn_limits()
-
-
-def _load_post_crisis_clear_after() -> int:
-    """Load post-crisis state clear-after turns from system_defaults.yaml, fallback to 3."""
-    try:
-        from utils.scenario_loader import get_scenario_loader
-
-        loader = get_scenario_loader()
-        defaults = loader.get_system_defaults()
-        return int(defaults.get("session", {}).get("post_crisis_clear_after", 3))
-    except Exception:
-        return 3
-
-
-POST_CRISIS_CLEAR_AFTER = _load_post_crisis_clear_after()
-
-
-def _load_identity_reminder_frequency() -> int:
-    """Load identity reminder frequency from system_defaults.yaml, fallback to 9."""
-    try:
-        from utils.scenario_loader import get_scenario_loader
-
-        loader = get_scenario_loader()
-        defaults = loader.get_system_defaults()
-        return int(defaults.get("session", {}).get("identity_reminder_frequency", 9))
-    except Exception:
-        return 9
-
-
-# Identity reminder frequency (every N turns in Reflective mode only)
-IDENTITY_REMINDER_FREQUENCY = _load_identity_reminder_frequency()
 
 
 class WellnessGuide:
@@ -244,9 +180,12 @@ class WellnessGuide:
             conversation_history = []
 
         # Truncate oversized input to prevent Ollama OOM / slow classification
-        if len(user_input) > MAX_INPUT_LENGTH:
-            logger.warning(f"Input truncated from {len(user_input)} to {MAX_INPUT_LENGTH} chars")
-            user_input = user_input[:MAX_INPUT_LENGTH]
+        max_input_length = int(
+            self.prompts.loader.get_default("ollama", "max_input_length", fallback=5000)
+        )
+        if len(user_input) > max_input_length:
+            logger.warning(f"Input truncated from {len(user_input)} to {max_input_length} chars")
+            user_input = user_input[:max_input_length]
 
         # Quick check if this looks like a practical request (for fallback purposes)
         practical_indicators = [
@@ -488,7 +427,7 @@ class WellnessGuide:
         # 4) Check turn limits by risk level - counted per domain, not per
         # session, so an established practical session doesn't make the first
         # turn in a sensitive domain trip that domain's limit.
-        turn_limit = TURN_LIMITS.get(domain, 15)
+        turn_limit = self._get_turn_limit(domain)
         if self.domain_turn_counts.get(domain, 0) >= turn_limit:
             self._log_policy(
                 "turn_limit_reached",
@@ -526,7 +465,10 @@ class WellnessGuide:
 
         # Add identity reminder periodically (only for non-practical conversations)
         identity_reminder = ""
-        if not is_practical and self.session_turn_count % IDENTITY_REMINDER_FREQUENCY == 0:
+        identity_reminder_frequency = int(
+            self.prompts.loader.get_default("session", "identity_reminder_frequency", fallback=9)
+        )
+        if not is_practical and self.session_turn_count % identity_reminder_frequency == 0:
             identity_reminder = (
                 "\n\n[Remember: Include a brief reminder that you are software, not a person.]"
             )
@@ -554,8 +496,11 @@ class WellnessGuide:
                 "The system responded correctly to protect the user. "
                 "If they mention the intervention, acknowledge calmly without self-criticism.]"
             )
-            # Clear the state after 3 turns
-            if self.session_turn_count > self.post_crisis_turn + POST_CRISIS_CLEAR_AFTER:
+            # Clear the state after the configured number of turns
+            post_crisis_clear_after = int(
+                self.prompts.loader.get_default("session", "post_crisis_clear_after", fallback=3)
+            )
+            if self.session_turn_count > self.post_crisis_turn + post_crisis_clear_after:
                 self.post_crisis_turn = None
 
         full_prompt = (
@@ -646,6 +591,7 @@ class WellnessGuide:
         6. Generate response
         7. Post-process for safety
         """
+        prepared = None
         try:
             prepared = self._prepare_response(
                 user_input,
@@ -666,7 +612,7 @@ class WellnessGuide:
         except Exception as e:
             logger.error(f"Error generating response: {str(e)}")
             return self._get_fallback_response(
-                is_practical=prepared.is_likely_practical if "prepared" in dir() else False
+                is_practical=prepared.is_likely_practical if prepared else False
             )
 
     def generate_response_stream(
@@ -687,6 +633,7 @@ class WellnessGuide:
         single chunk. The accumulated response is stored on
         self._last_streamed_response for post-stream metadata population.
         """
+        prepared = None
         try:
             prepared = self._prepare_response(
                 user_input,
@@ -810,7 +757,7 @@ class WellnessGuide:
         except Exception as e:
             logger.error(f"Error in streaming response: {str(e)}")
             fallback = self._get_fallback_response(
-                is_practical=prepared.is_likely_practical if "prepared" in dir() else False
+                is_practical=prepared.is_likely_practical if prepared else False
             )
             self._last_streamed_response = fallback
             yield fallback
@@ -990,6 +937,16 @@ class WellnessGuide:
         # This will be handled by injecting post-crisis context into the system prompt
         # For now, let normal processing continue but keep the state for prompt injection
         return None
+
+    def _get_turn_limit(self, domain: str) -> int:
+        """Per-domain turn limit — YAML override merged over the hardcoded defaults.
+
+        Read at call time (not import time) so reload_scenarios() picks up
+        edits to system_defaults.yaml without a restart.
+        """
+        configured = self.prompts.loader.get_default("session", "turn_limits", fallback=None)
+        limits = {**_DEFAULT_TURN_LIMITS, **configured} if configured else _DEFAULT_TURN_LIMITS
+        return limits.get(domain, 15)
 
     def _get_turn_limit_response(self, domain: str) -> str:
         """Return response when session turn limit is reached."""

--- a/src/models/conversation_session.py
+++ b/src/models/conversation_session.py
@@ -52,20 +52,6 @@ class ConnectionSteering:
         self.network_empty = network_empty
 
 
-def _load_confidence_threshold() -> float:
-    """Load intent detection confidence threshold from system_defaults.yaml, fallback to 0.6."""
-    try:
-        loader = get_scenario_loader()
-        defaults = loader.get_system_defaults()
-        return float(defaults.get("classification", {}).get("confidence_threshold", 0.6))
-    except Exception:
-        return 0.6
-
-
-# Minimum confidence for auto-detected intent and task category to be accepted.
-_CONFIDENCE_THRESHOLD = _load_confidence_threshold()
-
-
 class ConversationSession:
     """
     Framework-agnostic conversation session manager.
@@ -109,6 +95,21 @@ class ConversationSession:
     def turn_count(self) -> int:
         """Number of user messages in this session."""
         return sum(1 for m in self.messages if m["role"] == "user")
+
+    @property
+    def _confidence_threshold(self) -> float:
+        """Minimum confidence for auto-detected intent and task category.
+
+        Read at call time (not import time) so reload_scenarios() picks up
+        edits to system_defaults.yaml without a restart. Falls back to 0.6
+        on any unreadable value - config problems must not break messaging.
+        """
+        try:
+            return float(
+                self.loader.get_default("classification", "confidence_threshold", fallback=0.6)
+            )
+        except (TypeError, ValueError):
+            return 0.6
 
     def process_message(self, user_input: str) -> ConversationResult:
         """
@@ -243,7 +244,7 @@ class ConversationSession:
             else:
                 # Auto-detect intent from first message
                 detected_intent, confidence = self.classifier.detect_intent(user_input)
-                if confidence >= _CONFIDENCE_THRESHOLD:
+                if confidence >= self._confidence_threshold:
                     self.tracker.record_session_intent(detected_intent, auto_detected=True)
                     self.session_intent = detected_intent
 
@@ -292,7 +293,7 @@ class ConversationSession:
             domain = self.guide.last_risk_assessment.get("domain", "")
             if domain == "logistics":
                 task_category, confidence = self.classifier.detect_task_category(user_input)
-                if task_category and confidence >= _CONFIDENCE_THRESHOLD:
+                if task_category and confidence >= self._confidence_threshold:
                     self.tracker.record_task_category(task_category)
                     self.last_task_category = task_category
 

--- a/tests/test_wellness_guide.py
+++ b/tests/test_wellness_guide.py
@@ -3677,3 +3677,30 @@ class TestPerDomainTurnLimits:
         guide.domain_turn_counts = {"logistics": 5, "health": 2}
         guide.reset_session()
         assert guide.domain_turn_counts == {}
+
+
+class TestConfigHotReload:
+    """Config values are read at call time, not baked in at import time."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        with patch("models.ai_wellness_guide.settings") as mock:
+            mock.OLLAMA_HOST = "http://localhost:11434"
+            mock.OLLAMA_MODEL = "llama2"
+            mock.OLLAMA_TEMPERATURE = 0.7
+            yield mock
+
+    @pytest.fixture
+    def guide(self, mock_settings):
+        from models.ai_wellness_guide import WellnessGuide
+
+        return WellnessGuide()
+
+    def test_turn_limit_reads_loader_at_call_time(self, guide):
+        """A YAML override picked up by the loader takes effect without restart."""
+        with patch.object(guide.prompts.loader, "get_default", return_value={"health": 3}):
+            assert guide._get_turn_limit("health") == 3
+
+    def test_turn_limit_unknown_domain_defaults(self, guide):
+        with patch.object(guide.prompts.loader, "get_default", return_value=None):
+            assert guide._get_turn_limit("no_such_domain") == 15


### PR DESCRIPTION
## Summary

Three cleanups from the 2026-07-03 review:

**1. Config hot-reload actually works now.** Five tunables were baked into module-level constants at import time: `MAX_INPUT_LENGTH`, `TURN_LIMITS`, `POST_CRISIS_CLEAR_AFTER`, `IDENTITY_REMINDER_FREQUENCY` (`ai_wellness_guide.py`) and `_CONFIDENCE_THRESHOLD` (`conversation_session.py`). `reload_scenarios()` silently never refreshed them, undermining the "tune YAML without touching Python" contract. They are now loader lookups at the use sites (the loader caches YAML, so this is cheap); the four near-identical `_load_*()` module functions are deleted. The session threshold keeps the original fail-safe-to-0.6 on unreadable values - config problems must not break message processing.

**2. `"prepared" in dir()`** in both `generate_response` exception handlers replaced with an explicit `prepared = None` before the `try`.

**3. Safety-claim accuracy.** The mid-stream streaming buffer was documented as intercepting "harmful content", which overstates it: `_contains_harmful_content()` matches the manipulative-voice patterns from `safe_alternatives.yaml` (false intimacy, dependency-encouraging phrasing), not dangerous-instruction content - blocking harmful *requests* is the input-side layers' job. The `THREAT_MODEL.md` engineering-controls row, `CLAUDE.md` key-patterns entry, and `docs/architecture.md` streaming box now say exactly what it does. (Scanning output with the Phase 21 safety model is already noted as a stretch goal in the roadmap.)

## Type of change

- [x] Chore / documentation accuracy

## Testing

- Two new tests pin the call-time-read behavior (`TestConfigHotReload`): a patched loader value takes effect immediately in `_get_turn_limit`, and unknown domains fall back to 15
- Full suite: `pytest tests/ -m "not conversation"` - **1065 passed** (1063 + 2 new), 20 deselected
- Domain eval unaffected by construction (`run_domain_eval.py` exercises `RiskClassifier` directly; this PR touches guide/session config plumbing only) - run for the record, result noted in a comment if it lands after merge
- `black` + `flake8` pre-commit hooks: passed