### PR TITLE
feat: Phase 23.1 - restraint-memory negative invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Added (Phase 23.1 - restraint-memory negative invariant)
+- The memory principle is now architectural and falsifiable: every field the app
+  persists must appear in the new `restraint_memory` allowlist in
+  `scenarios/config/system_defaults.yaml` (`allowed_fields` for the JSON backend,
+  `allowed_columns` for SQLite, plus a `forbidden_field_names` deny-list -
+  message/content/transcript/persona/preference/etc. may not appear anywhere).
+  `tests/test_restraint_memory.py` exercises every public persistence API against
+  both backends and fails the build on any field outside the allowlist - persisting
+  a new field becomes a conscious, reviewed decision instead of a side effect.
+  Documented as a CLAUDE.md key pattern and a THREAT_MODEL.md engineering-controls
+  row. (MANIFESTO.md one-liner deferred: the manifesto-guard CI rule requires a
+  discussion issue first)
+- What the invariant caught on its first run: a dormant `user_input` parameter in
+  `StorageBackend.add_session_intent` (interface, both backends, and a SQLite
+  column) - never populated by any caller, but a standing capability to persist
+  raw user messages. The write path is removed; the legacy column must now be
+  provably empty (asserted by the test) until a schema v3 migration drops it.
+  `self_reports.content` (the user's self-report answer stored under a deny-listed
+  column name) is documented as the second legacy exception, to be renamed
+  `response` in v3
+- Consciously allowlisted free-text fields, with rationale in the YAML: check-in
+  notes, independence notes, self-report responses (user-entered form input),
+  trusted-network contact data, and `handoffs.message_preview` (first 100 chars of
+  the user's outreach message to a trusted person - powers the handoff follow-up;
+  outreach text, not conversation content)
+- `TESTING_CHECKLIST.md`: invariant added to the automated gates; corrected the
+  stale "domain eval >=87%" expectation to the real baseline (86%, 81/94 on
+  mistral:7b-instruct)
+
 ### Changed
 - Minimum supported Python is now 3.10 (was 3.9, EOL since October 2025). CI matrix
   updated to 3.10-3.14, adding coverage for 3.13 and 3.14 which were previously

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ tests/
 ├── test_data_contracts.py          # RiskAssessment, LLMClassification
 ├── test_conversation_session.py    # ConversationSession orchestration
 ├── test_validate_scenarios.py      # YAML schema validation
+├── test_restraint_memory.py        # Negative invariant: persisted fields ⊆ allowlist
 └── classification/
     ├── domain_corpus.yaml          # 94 labeled examples for accuracy eval
     └── run_domain_eval.py          # Per-domain accuracy report
@@ -157,6 +158,13 @@ the singleton holds the cache and the write-gate state.
 **Defense-in-depth write protection**: UI disabling → `write_gate.py` flag →
 storage method checks. All three must pass for a write to succeed. Changes to
 storage must go through `StorageBackend`, not the underlying db directly.
+
+**Restraint-memory invariant** (Phase 23.1): every field the app persists must
+be listed in `scenarios/config/system_defaults.yaml` under `restraint_memory`
+(`allowed_fields` for JSON, `allowed_columns` for SQLite).
+`tests/test_restraint_memory.py` fails the build otherwise - persisting a new
+field is a conscious, reviewed decision, never a side effect. Conversation
+content and preference/persona data are never persistable.
 
 ## Roadmap
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,10 +156,12 @@ whichever label the LLM reaches first wins forever. Measured consequences:
 The invariant must exist before Phase 22 adds cross-session persistence, so that
 what the daemon is *able* to remember is constrained by design, not audited after.
 
-- [ ] Define the exhaustive allowlist of persistable fields in `scenarios/config/system_defaults.yaml` (`restraint_memory.allowed_fields`)
-- [ ] Add a property test (`tests/test_restraint_memory.py`) that serializes every persisted structure (session summaries, wellness-tracker state, handoff log, policy_events) and asserts NO field outside the allowlist is present - in particular, no raw user-message text and no derived "preference"/"persona" field
-- [ ] CI gate: blocking. A PR that persists conversation content or a rapport profile fails the build.
-- [ ] Document the invariant in MANIFESTO.md (one line) and CLAUDE.md (architecture note)
+- [x] Define the exhaustive allowlist of persistable fields in `scenarios/config/system_defaults.yaml` (`restraint_memory.allowed_fields` for JSON, `allowed_columns` for SQLite, plus `forbidden_field_names` deny-list)
+- [x] Add a property test (`tests/test_restraint_memory.py`) that serializes every persisted structure (wellness-tracker state, trusted network, handoff log, policy_events - both backends) and asserts NO field outside the allowlist is present - in particular, no raw user-message text and no derived "preference"/"persona" field
+- [x] CI gate: blocking. A PR that persists conversation content or a rapport profile fails the build.
+- [x] Document the invariant in CLAUDE.md (key pattern) and THREAT_MODEL.md (engineering-controls row)
+- [ ] MANIFESTO.md one-liner: blocked by the manifesto-guard CI rule (changes require a discussion issue first) - open that issue when convenient
+- [x] Found by the invariant on first run: a dormant `user_input` parameter/column in the storage layer (never populated, but a standing capability to persist raw messages) - write path removed; column asserted empty until the schema v3 migration drops it. `self_reports.content` (the user's self-report answer under a deny-listed name) documented as a legacy exception to rename in v3.
 
 ### 23.2 Cross-Session Decay
 - [ ] Extend the per-turn context decay (Phase 6.5) to cross-session safety state: dependency-score trajectory and sensitive-domain counters decay toward baseline after a configurable quiet period (default 30 days with no sensitive sessions in that domain)

--- a/TESTING_CHECKLIST.md
+++ b/TESTING_CHECKLIST.md
@@ -19,11 +19,15 @@ python tests/classification/run_domain_eval.py
 # Structural conversation quality (no Ollama required)
 pytest tests/test_conversation_quality.py -m "not conversation" -v
 
+# Restraint-memory negative invariant (persisted fields ⊆ allowlist)
+pytest tests/test_restraint_memory.py -v
+
 # Version consistency
 python scripts/check_version.py
 ```
 
-Expected: `pytest` all green, domain eval ≥87% overall, version check passes.
+Expected: `pytest` all green, domain eval at or above the 86% baseline
+(81/94 on mistral:7b-instruct), version check passes.
 
 ---
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -58,6 +58,7 @@ not a refactor. The prose above explains *why* each control exists; this maps
 | Atomic writes | `mkstemp` + `fsync` + `os.replace` (no torn files on crash) | `src/utils/storage_backend.py` |
 | `OLLAMA_HOST` validation | http(s) scheme checked at config load | `src/config/settings.py` |
 | Non-root container | `gosu` drops root to `PUID:PGID`; Ollama bound to `127.0.0.1` | `docker/entrypoint.sh`, `docker-compose.yml` |
+| Restraint-memory invariant | Property test serializes every persisted structure (both backends) and fails the build if any field outside the allowlist is written - no conversation content, no preference/persona data, ever | `tests/test_restraint_memory.py`, `scenarios/config/system_defaults.yaml` (`restraint_memory`) |
 
 ## Known gaps
 

--- a/scenarios/config/system_defaults.yaml
+++ b/scenarios/config/system_defaults.yaml
@@ -130,3 +130,79 @@ retention:
   max_task_pattern_uses: 100
   max_policy_events: 1000
   historical_days: 3650           # ~10 years for full history queries
+
+# --- Restraint Memory (Phase 23.1) ---
+# The exhaustive allowlist of persistable fields. This is the negative
+# invariant that makes "memory as guardrail, not rapport" falsifiable:
+# tests/test_restraint_memory.py serializes every persisted structure and
+# fails the build if ANY field outside this list is written. Adding a field
+# here is a conscious, reviewed decision - never a side effect.
+#
+# Consciously allowed free-text fields (user-entered form input, never
+# conversation transcript or derived preference/persona data):
+#   check_ins.notes            - the daily check-in note the user types
+#   independence_records.notes - the "I did it myself" note the user types
+#   self_reports.response      - the user's answer to a self-report prompt
+#   people.* / reach_outs.*    - trusted-network contact data the user enters
+#   handoffs.message_preview   - first 100 chars of the outreach message the
+#                                user sent to a trusted person (powers the
+#                                handoff follow-up); outreach text, not
+#                                conversation content
+# Free-form "details" dicts are additionally scanned against the forbidden
+# key names below.
+restraint_memory:
+  forbidden_field_names:        # must not appear ANYWHERE in persisted data
+    - message
+    - messages
+    - content
+    - conversation
+    - transcript
+    - user_input
+    - prompt
+    - persona
+    - preference
+    - preferences
+    - profile
+  allowed_fields:
+    wellness_root: [schema_version, created_at, check_ins, usage_sessions,
+                    policy_events, session_intents, task_patterns,
+                    independence_records, handoff_events, self_reports]
+    check_ins: [date, datetime, feeling_score, notes]
+    usage_sessions: [date, datetime, domains_touched, duration_minutes, hour,
+                     max_risk_weight, turn_count]
+    policy_events: [action_taken, date, datetime, domain, policy_type, risk_weight]
+    session_intents: [auto_detected, date, datetime, intent, was_check_in]
+    task_patterns: [count, count_at_last_shown, dismissal_count, first_use,
+                    graduation_shown_count, last_dismissal, last_graduation_shown,
+                    last_use, uses]
+    task_pattern_uses: [date, datetime]
+    independence_records: [category, date, datetime, notes]
+    handoff_events: [context, date, datetime, details, domain, event_type, outcome]
+    self_reports: [date, datetime, details, response, type]
+    network_root: [schema_version, created_at, people, reach_outs, handoffs]
+    people: [added_at, contact, domains, id, last_contact, name, notes, relationship]
+    reach_outs: [date, datetime, method, notes, person_name, topic]
+    handoffs: [context, date, datetime, domain, follow_up_shown, id,
+               message_preview, outcome, person_name, status]
+  # SQLite column allowlist (column names diverge from the JSON field names).
+  # Structural/bookkeeping columns carry no user data. Legacy exceptions are
+  # deny-named columns that predate the invariant; a schema v3 migration will
+  # drop session_intents.user_input (dormant - asserted empty by the test)
+  # and rename self_reports.content to response.
+  allowed_columns:
+    schema_info: [version, migrated_at, description]
+    check_ins: [id, feeling_score, notes, created_at]
+    usage_sessions: [id, started_at, ended_at, duration_minutes, turn_count,
+                     max_risk_weight, domains_touched, intent, created_at]
+    policy_events: [id, session_id, event_type, domain, action_taken,
+                    explanation, risk_weight, created_at]
+    session_intents: [id, session_id, intent, user_input, created_at]
+    independence_records: [id, task_category, milestone, notes, created_at]
+    handoff_events: [id, handoff_type, domain, person_name, completed, notes, created_at]
+    self_reports: [id, report_type, content, score, created_at]
+    task_patterns: [id, pattern_type, count, last_seen, metadata, created_at]
+    trusted_people: [id, name, relationship, contact, notes, domains, added_at, last_contact]
+    reach_outs: [id, person_id, method, notes, outcome, created_at]
+  legacy_deny_named_columns:
+    session_intents: [user_input]   # dormant; must be empty; drop in schema v3
+    self_reports: [content]         # holds the user's self-report answer; rename in v3

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -541,10 +541,9 @@ def migrate_from_json(wellness_json_path: Path, network_json_path: Path) -> bool
                 # Session intents
                 for intent in wellness.get("session_intents", []):
                     db.execute(
-                        "INSERT INTO session_intents (intent, user_input, created_at) VALUES (?, ?, ?)",
+                        "INSERT INTO session_intents (intent, created_at) VALUES (?, ?)",
                         (
                             intent.get("intent", "unknown"),
-                            intent.get("user_input", ""),
                             intent.get(
                                 "timestamp", intent.get("created_at", datetime.now().isoformat())
                             ),

--- a/src/utils/storage_backend.py
+++ b/src/utils/storage_backend.py
@@ -132,7 +132,6 @@ class StorageBackend(ABC):
         intent: str,
         was_check_in: bool = False,
         auto_detected: bool = False,
-        user_input: str = "",
     ) -> Dict:
         """Record session intent."""
         pass
@@ -486,7 +485,6 @@ class JSONBackend(StorageBackend):
         intent: str,
         was_check_in: bool = False,
         auto_detected: bool = False,
-        user_input: str = "",
     ) -> Dict:
         self._ensure_write_allowed()
         data = self._load_wellness()
@@ -497,7 +495,6 @@ class JSONBackend(StorageBackend):
             "intent": intent,
             "was_check_in": was_check_in,
             "auto_detected": auto_detected,
-            "user_input": user_input,
         }
         if "session_intents" not in data:
             data["session_intents"] = []
@@ -1102,12 +1099,9 @@ class SQLiteBackend(StorageBackend):
         intent: str,
         was_check_in: bool = False,
         auto_detected: bool = False,
-        user_input: str = "",
     ) -> Dict:
         self._ensure_write_allowed()
-        cursor = self.db.execute(
-            "INSERT INTO session_intents (intent, user_input) VALUES (?, ?)", (intent, user_input)
-        )
+        cursor = self.db.execute("INSERT INTO session_intents (intent) VALUES (?)", (intent,))
         self.db.commit()
 
         return {
@@ -1117,7 +1111,6 @@ class SQLiteBackend(StorageBackend):
             "intent": intent,
             "was_check_in": was_check_in,
             "auto_detected": auto_detected,
-            "user_input": user_input,
         }
 
     def get_session_intents_for_period(self, start_date: date, end_date: date = None) -> List[Dict]:

--- a/tests/test_restraint_memory.py
+++ b/tests/test_restraint_memory.py
@@ -1,0 +1,259 @@
+"""
+Restraint Memory negative invariant (Phase 23.1).
+
+empathySync remembers only what protects the user, never what deepens
+engagement. This test makes that guarantee falsifiable: it exercises every
+public persistence API, then serializes everything that was written and
+asserts that no field outside the allowlist in
+scenarios/config/system_defaults.yaml (restraint_memory.allowed_fields)
+exists - in particular, no raw conversation content and no derived
+preference/persona field.
+
+A PR that persists a new field fails this test until the field is added to
+the allowlist - which makes persisting data a conscious, reviewed decision
+instead of a side effect. This is a blocking CI gate.
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+ALLOWLIST_PATH = Path(__file__).parent.parent / "scenarios" / "config" / "system_defaults.yaml"
+
+# Maps a top-level key in each JSON file to its allowlist entry.
+STRUCTURE_MAP = {
+    "wellness_data.json": {
+        "_root": "wellness_root",
+        "check_ins": "check_ins",
+        "usage_sessions": "usage_sessions",
+        "policy_events": "policy_events",
+        "session_intents": "session_intents",
+        "independence_records": "independence_records",
+        "handoff_events": "handoff_events",
+        "self_reports": "self_reports",
+    },
+    "trusted_network.json": {
+        "_root": "network_root",
+        "people": "people",
+        "reach_outs": "reach_outs",
+        "handoffs": "handoffs",
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def restraint_config():
+    config = yaml.safe_load(open(ALLOWLIST_PATH))["restraint_memory"]
+    return config
+
+
+def _exercise_all_persistence_apis(tmp_path, use_sqlite):
+    """Write one representative record through every public persistence API."""
+    import utils.database as db_module
+    from utils.storage_backend import reset_storage_backend
+
+    db_module._connection = None
+    db_module._db_path = None
+    reset_storage_backend()
+
+    with (
+        patch("utils.wellness_tracker.settings") as tracker_settings,
+        patch("utils.trusted_network.settings") as network_settings,
+        patch("utils.storage_backend.settings") as backend_settings,
+        patch("utils.database.settings") as db_settings,
+        patch("config.settings.settings") as core_settings,
+    ):
+        for mock in (
+            tracker_settings,
+            network_settings,
+            backend_settings,
+            db_settings,
+            core_settings,
+        ):
+            mock.DATA_DIR = tmp_path
+            mock.USE_SQLITE = use_sqlite
+            mock.ENABLE_DEVICE_LOCK = False
+            mock.DATA_RETENTION_DAYS = 90
+        from utils.wellness_tracker import WellnessTracker
+        from utils.trusted_network import TrustedNetwork
+
+        t = WellnessTracker()
+        t.add_check_in(4, notes="feeling ok")
+        t.add_session(
+            duration_minutes=10,
+            turn_count=5,
+            domains_touched=["logistics"],
+            max_risk_weight=2.0,
+        )
+        t.log_policy_event("crisis_stop", "crisis", 10.0, "Immediate crisis redirect")
+        t.record_session_intent("practical", auto_detected=True)
+        t.record_task_category("email_drafting")
+        t.record_graduation_shown("email_drafting")
+        t.record_graduation_dismissal("email_drafting")
+        t.record_independence("email_drafting", notes="did it myself")
+        t.log_handoff_event(
+            "initiated",
+            context="after_difficult_task",
+            domain="relationships",
+            details={"person": "Sam"},
+        )
+        t.record_self_report("usefulness", "yes", details={"score": 3})
+
+        n = TrustedNetwork()
+        n.add_person(
+            "Sam",
+            relationship="friend",
+            contact="sam@example.com",
+            notes="old friend",
+            domains=["relationships"],
+        )
+        n.log_reach_out("Sam", method="text", topic="checking in", notes="felt good")
+        n.log_handoff_initiated("Sam", "relationships", message_sent="Hey, got a minute?")
+
+    if use_sqlite:
+        db_module.close_db()
+        db_module._connection = None
+        db_module._db_path = None
+    reset_storage_backend()
+
+
+def _walk_forbidden(obj, forbidden, path="root"):
+    """Recursively assert no forbidden key name appears anywhere."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert k.lower() not in forbidden, (
+                f"Forbidden field '{k}' persisted at {path} - "
+                "conversation content and preference/persona data must never be stored "
+                "(restraint_memory invariant, Phase 23.1)"
+            )
+            _walk_forbidden(v, forbidden, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            _walk_forbidden(item, forbidden, f"{path}[{i}]")
+
+
+class TestRestraintMemoryJSON:
+    """The invariant against the JSON backend (default)."""
+
+    @pytest.fixture()
+    def data_dir(self, tmp_path):
+        _exercise_all_persistence_apis(tmp_path, use_sqlite=False)
+        return tmp_path
+
+    def test_every_persisted_field_is_allowlisted(self, data_dir, restraint_config):
+        allowed = restraint_config["allowed_fields"]
+        checked_records = 0
+        for filename, structure in STRUCTURE_MAP.items():
+            payload = json.load(open(data_dir / filename))
+
+            root_allowed = set(allowed[structure["_root"]])
+            unexpected = set(payload.keys()) - root_allowed
+            assert not unexpected, (
+                f"{filename} persists top-level fields outside the allowlist: "
+                f"{sorted(unexpected)}. Add them to restraint_memory.allowed_fields "
+                "only as a conscious, reviewed decision."
+            )
+
+            for key, entry_name in structure.items():
+                if key == "_root":
+                    continue
+                for record in payload.get(key, []):
+                    unexpected = set(record.keys()) - set(allowed[entry_name])
+                    assert not unexpected, (
+                        f"{filename}:{key} persists fields outside the allowlist: "
+                        f"{sorted(unexpected)}"
+                    )
+                    checked_records += 1
+
+            # task_patterns is a dict of per-category stats, not a list
+            if "task_patterns" in payload:
+                for category, stats in payload["task_patterns"].items():
+                    unexpected = set(stats.keys()) - set(allowed["task_patterns"])
+                    assert not unexpected, (
+                        f"task_patterns[{category}] persists fields outside the "
+                        f"allowlist: {sorted(unexpected)}"
+                    )
+                    for use in stats.get("uses", []):
+                        unexpected = set(use.keys()) - set(allowed["task_pattern_uses"])
+                        assert not unexpected, (
+                            f"task_patterns[{category}].uses persists fields outside "
+                            f"the allowlist: {sorted(unexpected)}"
+                        )
+                    checked_records += 1
+
+        assert checked_records >= 10, (
+            "The exercise step wrote fewer record types than expected - "
+            "if a persistence API was removed, update this test"
+        )
+
+    def test_no_forbidden_field_anywhere(self, data_dir, restraint_config):
+        """Deny-list scan covers free-form dicts (e.g. handoff details) too."""
+        forbidden = {f.lower() for f in restraint_config["forbidden_field_names"]}
+        for filename in STRUCTURE_MAP:
+            _walk_forbidden(json.load(open(data_dir / filename)), forbidden, filename)
+
+
+class TestRestraintMemorySQLite:
+    """The invariant against the SQLite backend: column names are the schema."""
+
+    @pytest.fixture()
+    def db_conn(self, tmp_path):
+        _exercise_all_persistence_apis(tmp_path, use_sqlite=True)
+        db_files = list(tmp_path.glob("*.db"))
+        assert db_files, "SQLite backend did not create a database file"
+        conn = sqlite3.connect(db_files[0])
+        yield conn
+        conn.close()
+
+    def test_every_column_is_allowlisted(self, db_conn, restraint_config):
+        allowed_columns = restraint_config["allowed_columns"]
+        legacy = restraint_config["legacy_deny_named_columns"]
+        forbidden = {f.lower() for f in restraint_config["forbidden_field_names"]}
+
+        tables = [
+            r[0]
+            for r in db_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' " "AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+        assert tables, "no tables created"
+        for table in tables:
+            assert table in allowed_columns, (
+                f"SQLite table '{table}' is not in restraint_memory.allowed_columns. "
+                "Persisting a new table is a conscious, reviewed decision."
+            )
+            columns = [r[1] for r in db_conn.execute(f"PRAGMA table_info({table})")]
+            for column in columns:
+                assert column in allowed_columns[table], (
+                    f"SQLite table '{table}' column '{column}' is not in the "
+                    "restraint_memory allowlist. Persisting a new column is a "
+                    "conscious, reviewed decision."
+                )
+                if column.lower() in forbidden:
+                    assert column in legacy.get(table, []), (
+                        f"SQLite table '{table}' has forbidden column '{column}' "
+                        "that is not a documented legacy exception"
+                    )
+
+    def test_dormant_user_input_column_stays_empty(self, db_conn):
+        """The legacy session_intents.user_input column must never hold data.
+
+        The write path was removed in Phase 23.1; the column itself is dropped
+        by the planned schema v3 migration. Until then, any value appearing
+        here means raw message text is being persisted again.
+        """
+        rows = db_conn.execute(
+            "SELECT user_input FROM session_intents "
+            "WHERE user_input IS NOT NULL AND user_input != ''"
+        ).fetchall()
+        assert not rows, (
+            f"session_intents.user_input contains data: {rows[:3]} - "
+            "raw user input must never be persisted (restraint_memory invariant)"
+        )


### PR DESCRIPTION
## Summary

Implements Phase 23.1 (pulled ahead of Phase 22 per the roadmap): the memory principle - *empathySync remembers only what protects the user, never what deepens engagement* - is now enforced by the build, not by developer discipline.

**The invariant:**
- `scenarios/config/system_defaults.yaml` gains a `restraint_memory` section: `allowed_fields` (JSON backend), `allowed_columns` (SQLite backend - column names diverge from JSON field names), and `forbidden_field_names` (message/content/transcript/persona/preference/... may not appear anywhere, including inside free-form `details` dicts)
- `tests/test_restraint_memory.py` exercises **every public persistence API** against **both backends**, then walks everything written: JSON keys must be ⊆ the allowlist, SQLite tables/columns must be ⊆ the column allowlist, and the deny-list is scanned recursively. A PR that persists a new field fails CI until the field is added to the allowlist - a conscious, reviewed decision, never a side effect. This is the constraint Phase 22's daemon will be born inside.

**What the invariant caught on its first run** (working as designed):
- A dormant `user_input` parameter in `StorageBackend.add_session_intent` - present in the abstract interface, both backends, and as a SQLite column, but **never populated by any caller**. A standing, unused capability to persist raw user messages. The write path is removed in this PR; the legacy column must now be provably empty (a dedicated test asserts it) until a schema v3 migration drops it.
- `self_reports.content` - the user's self-report answer stored under a deny-listed column name (the JSON backend calls the same data `response`). Documented as the second legacy exception, to be renamed in v3.

**Consciously allowlisted free-text fields** (rationale in the YAML): check-in notes, independence notes, self-report responses (user-entered form input, not conversation), trusted-network contact data, and `handoffs.message_preview` (first 100 chars of the user's outreach message to a trusted person - powers the handoff follow-up; outreach text, not conversation content).

**Docs:** CLAUDE.md key-pattern entry, THREAT_MODEL.md engineering-controls row, TESTING_CHECKLIST.md gains the invariant (and its stale "eval >=87%" expectation corrected to the real 86% baseline), ROADMAP 23.1 boxes ticked. The MANIFESTO.md one-liner is deferred: the manifesto-guard CI rule requires a discussion issue first - happy to open it.

## Type of change

- [x] Feature (safety architecture)

## Testing

- Four new tests: JSON allowlist walk, recursive deny-list scan, SQLite table/column allowlist, dormant-column-stays-empty assertion. The exercise step self-checks (fails if fewer record types than expected get written, so a removed API can't silently shrink coverage)
- Full suite: `pytest tests/ -m "not conversation"` - **1069 passed** (1065 + 4 new), 20 deselected
- Domain eval: running, will confirm at baseline in a comment (storage layer only - no classification path touched)
- `black` + `flake8`: passed