### PR TITLE
feat: schema v3 migration - drop dormant session_intents.user_input column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Changed
+- Schema v3 migration: dropped the dormant `session_intents.user_input` SQLite
+  column (`src/utils/database.py`, `_migrate_v2_to_v3`). The write path was
+  removed in Phase 23.1; the column itself was a standing capability to persist
+  raw message text. Existing databases rebuild the table on startup, preserving
+  all other columns. The restraint-memory invariant test now asserts the column
+  is gone rather than merely empty; a migration test covers the v2->v3 rebuild.
+  Renaming `self_reports.content` to `response` remains deferred - it touches
+  both backends and unversioned JSON data - and stays a documented legacy exception.
+
 ## v1.12.0 (2026-07-04) - Restraint Memory & Safety Groundwork
 
 ### Added (Phase 21.1 - safety-model evaluation)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -200,7 +200,7 @@ what the daemon is *able* to remember is constrained by design, not audited afte
 - [x] CI gate: blocking. A PR that persists conversation content or a rapport profile fails the build.
 - [x] Document the invariant in CLAUDE.md (key pattern) and THREAT_MODEL.md (engineering-controls row)
 - [ ] MANIFESTO.md one-liner: blocked by the manifesto-guard CI rule (changes require a discussion issue first) - open that issue when convenient
-- [x] Found by the invariant on first run: a dormant `user_input` parameter/column in the storage layer (never populated, but a standing capability to persist raw messages) - write path removed; column asserted empty until the schema v3 migration drops it. `self_reports.content` (the user's self-report answer under a deny-listed name) documented as a legacy exception to rename in v3.
+- [x] Found by the invariant on first run: a dormant `user_input` parameter/column in the storage layer (never populated, but a standing capability to persist raw messages) - write path removed in 23.1, and the SQLite column dropped by the schema v3 migration (`database.py` `_migrate_v2_to_v3`; the invariant test now asserts the column is gone, not merely empty). `self_reports.content` (the user's self-report answer under a deny-listed name) stays a documented legacy exception; renaming it to `response` is deferred (touches both backends and unversioned JSON data).
 
 ### 23.2 Cross-Session Decay
 - [ ] Extend the per-turn context decay (Phase 6.5) to cross-session safety state: dependency-score trajectory and sensitive-domain counters decay toward baseline after a configurable quiet period (default 30 days with no sensitive sessions in that domain)

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -207,6 +207,7 @@ CREATE TABLE reach_outs (
 |---------|-------------|
 | v1 | Initial schema |
 | v2 | Added `ON DELETE CASCADE` to reach_outs foreign key |
+| v3 | Dropped the dormant `session_intents.user_input` column (raw message text must never be persistable; enforced by the restraint-memory invariant) |
 
 Migrations run automatically on startup via `_run_migrations()` in `database.py`. After migration, `PRAGMA foreign_key_check` verifies no FK violations.
 

--- a/scenarios/config/system_defaults.yaml
+++ b/scenarios/config/system_defaults.yaml
@@ -186,9 +186,9 @@ restraint_memory:
                message_preview, outcome, person_name, status]
   # SQLite column allowlist (column names diverge from the JSON field names).
   # Structural/bookkeeping columns carry no user data. Legacy exceptions are
-  # deny-named columns that predate the invariant; a schema v3 migration will
-  # drop session_intents.user_input (dormant - asserted empty by the test)
-  # and rename self_reports.content to response.
+  # deny-named columns that predate the invariant. Schema v3 dropped the dormant
+  # session_intents.user_input column; renaming self_reports.content to response
+  # remains deferred (touches both backends and unversioned JSON data).
   allowed_columns:
     schema_info: [version, migrated_at, description]
     check_ins: [id, feeling_score, notes, created_at]
@@ -196,7 +196,7 @@ restraint_memory:
                      max_risk_weight, domains_touched, intent, created_at]
     policy_events: [id, session_id, event_type, domain, action_taken,
                     explanation, risk_weight, created_at]
-    session_intents: [id, session_id, intent, user_input, created_at]
+    session_intents: [id, session_id, intent, created_at]
     independence_records: [id, task_category, milestone, notes, created_at]
     handoff_events: [id, handoff_type, domain, person_name, completed, notes, created_at]
     self_reports: [id, report_type, content, score, created_at]
@@ -204,5 +204,4 @@ restraint_memory:
     trusted_people: [id, name, relationship, contact, notes, domains, added_at, last_contact]
     reach_outs: [id, person_id, method, notes, outcome, created_at]
   legacy_deny_named_columns:
-    session_intents: [user_input]   # dormant; must be empty; drop in schema v3
-    self_reports: [content]         # holds the user's self-report answer; rename in v3
+    self_reports: [content]         # holds the user's self-report answer; rename deferred to a future migration

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -30,7 +30,7 @@ from config.settings import settings
 logger = logging.getLogger(__name__)
 
 # Current schema version - increment when schema changes
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Thread-local storage for connections
 _local = threading.local()
@@ -266,7 +266,6 @@ def _create_schema(conn: sqlite3.Connection):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id INTEGER REFERENCES usage_sessions(id),
             intent TEXT NOT NULL,
-            user_input TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
 
@@ -363,6 +362,8 @@ def _run_migrations(conn: sqlite3.Connection):
     # Run migrations in order
     if current_version < 2:
         _migrate_v1_to_v2(conn)
+    if current_version < 3:
+        _migrate_v2_to_v3(conn)
 
     # Future migrations would go here
 
@@ -412,6 +413,48 @@ def _migrate_v1_to_v2(conn: sqlite3.Connection):
 
     conn.commit()
     logger.info("Migration v1 -> v2 completed")
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection):
+    """
+    Drop the dormant session_intents.user_input column.
+
+    The write path for this column was removed in Phase 23.1 (raw user input
+    must never be persisted); the column itself lingered as a standing capability
+    to store message content. SQLite before 3.35 has no DROP COLUMN, so we
+    recreate the table without it. The restraint-memory invariant
+    (tests/test_restraint_memory.py) enforces that no such column returns.
+    """
+    logger.info("Running migration v2 -> v3: Dropping dormant session_intents.user_input")
+
+    conn.executescript(
+        """
+        -- Recreate session_intents without the user_input column
+        CREATE TABLE session_intents_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER REFERENCES usage_sessions(id),
+            intent TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        -- Copy existing data (user_input is intentionally not carried over)
+        INSERT INTO session_intents_new (id, session_id, intent, created_at)
+        SELECT id, session_id, intent, created_at FROM session_intents;
+
+        -- Drop old table
+        DROP TABLE session_intents;
+
+        -- Rename new table
+        ALTER TABLE session_intents_new RENAME TO session_intents;
+
+        -- Record migration
+        INSERT INTO schema_info (version, migrated_at, description)
+        VALUES (3, datetime('now'), 'Dropped dormant session_intents.user_input column');
+    """
+    )
+
+    conn.commit()
+    logger.info("Migration v2 -> v3 completed")
 
 
 # ==================== CONVENIENCE FUNCTIONS ====================

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -99,6 +99,59 @@ class TestDatabaseModule:
 
         assert version >= 1
 
+    def test_migration_v2_to_v3_drops_user_input(self, temp_data_dir):
+        """A v2 database is migrated to v3: session_intents.user_input is
+        dropped and the remaining columns' data survives."""
+        import sqlite3
+        import utils.database as db_module
+
+        db_module._connection = None
+        db_module._db_path = None
+        db_path = temp_data_dir / "empathySync.db"
+
+        # Build a minimal v2 database by hand (session_intents still has user_input)
+        raw = sqlite3.connect(db_path)
+        raw.executescript(
+            """
+            CREATE TABLE schema_info (
+                version INTEGER PRIMARY KEY,
+                migrated_at TEXT NOT NULL,
+                description TEXT
+            );
+            CREATE TABLE usage_sessions (id INTEGER PRIMARY KEY AUTOINCREMENT);
+            CREATE TABLE session_intents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER REFERENCES usage_sessions(id),
+                intent TEXT NOT NULL,
+                user_input TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO schema_info (version, migrated_at, description)
+            VALUES (2, datetime('now'), 'test seed v2');
+            INSERT INTO session_intents (intent, user_input, created_at)
+            VALUES ('practical', 'raw message text', '2026-01-01T00:00:00');
+            """
+        )
+        raw.commit()
+        raw.close()
+
+        with patch("utils.database.settings") as mock_settings:
+            mock_settings.DATA_DIR = temp_data_dir
+
+            conn = db_module.get_db()  # triggers _ensure_schema -> migrations
+
+            columns = [r[1] for r in conn.execute("PRAGMA table_info(session_intents)")]
+            assert "user_input" not in columns
+
+            row = conn.execute("SELECT intent, created_at FROM session_intents").fetchone()
+            assert row[0] == "practical"
+            assert row[1] == "2026-01-01T00:00:00"
+
+            version = conn.execute("SELECT MAX(version) FROM schema_info").fetchone()[0]
+            assert version == 3
+
+            db_module.close_db()
+
     def test_checkpoint_for_sync(self, temp_data_dir):
         """Test that checkpoint consolidates WAL."""
         import utils.database as db_module

--- a/tests/test_restraint_memory.py
+++ b/tests/test_restraint_memory.py
@@ -242,18 +242,16 @@ class TestRestraintMemorySQLite:
                         "that is not a documented legacy exception"
                     )
 
-    def test_dormant_user_input_column_stays_empty(self, db_conn):
-        """The legacy session_intents.user_input column must never hold data.
+    def test_user_input_column_is_gone(self, db_conn):
+        """The session_intents.user_input column must not exist.
 
-        The write path was removed in Phase 23.1; the column itself is dropped
-        by the planned schema v3 migration. Until then, any value appearing
-        here means raw message text is being persisted again.
+        The write path was removed in Phase 23.1 and the column itself was
+        dropped by the schema v3 migration. Its reappearance would mean a
+        standing capability to persist raw message text has returned.
         """
-        rows = db_conn.execute(
-            "SELECT user_input FROM session_intents "
-            "WHERE user_input IS NOT NULL AND user_input != ''"
-        ).fetchall()
-        assert not rows, (
-            f"session_intents.user_input contains data: {rows[:3]} - "
-            "raw user input must never be persisted (restraint_memory invariant)"
+        columns = [r[1] for r in db_conn.execute("PRAGMA table_info(session_intents)")]
+        assert "user_input" not in columns, (
+            "session_intents.user_input exists again - the schema v3 migration "
+            "dropped it because raw user input must never be persistable "
+            "(restraint_memory invariant)"
         )


### PR DESCRIPTION
## Summary

Completes the schema cleanup deferred from Phase 23.1. That phase removed the *write path* for `session_intents.user_input` (raw message text must never be persisted), but left the SQLite column in place as a dormant capability, test-guarded as empty. Schema **v3** drops the column outright.

- `src/utils/database.py`: `SCHEMA_VERSION` 2 -> 3; `session_intents` created without `user_input`; new `_migrate_v2_to_v3` rebuilds the table (the same table-rebuild pattern as the existing v1->v2 migration, since SQLite pre-3.35 has no `DROP COLUMN`); migration dispatched in `_run_migrations`. Existing databases migrate automatically on startup, preserving every other column.
- `scenarios/config/system_defaults.yaml`: `user_input` removed from the `session_intents` column allowlist and from `legacy_deny_named_columns`.
- `tests/test_restraint_memory.py`: the invariant test now asserts the column is **gone** (via `PRAGMA table_info`), not merely empty.
- `tests/test_persistence.py`: new `test_migration_v2_to_v3_drops_user_input` seeds a hand-built v2 DB with the column + a row, runs the migration, and asserts the column is dropped while `intent`/`created_at` survive and the version becomes 3.
- `docs/persistence.md`: v3 row added to the migrations table.

**Deliberately out of scope:** renaming `self_reports.content` to `response`. That touches three `add_self_report` methods, the JSON backend dict key, and unversioned JSON user data on disk - real migration risk for a cosmetic gain. It stays a documented legacy exception.

## Testing

- `pytest -m "not conversation"`: **1070 passed** (was 1069; +1 migration test), 20 deselected.
- Restraint-memory invariant and the new migration test both green.
- black + flake8 pass (pre-commit).