### PR TITLE
feat: additive LlamaGuard safety classifier (Phase 21.2, landed dark)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,15 @@ LLM_CLASSIFICATION_ENABLED=true
 # OLLAMA_MODEL for both classification and responses, which is the safest default.
 # OLLAMA_CLASSIFIER_MODEL=
 
+# Optional: dedicated safety guard model (Phase 21.2, off by default).
+# When set (e.g. llama-guard3:1b), an ADDITIVE LlamaGuard layer classifies input
+# hazards alongside the base classifier - it adds refusals, never replaces the
+# base pipeline, and fails open if unreachable. LlamaGuard categories are mapped,
+# not blanket-blocked: S6 (specialized medical/financial/legal advice) routes to
+# empathySync's existing restraint, not a refusal. Unset = disabled.
+# NOTE: landed but not yet wired into the pipeline as of Phase 21.2.
+# OLLAMA_SAFETY_MODEL=
+
 # ===================
 # Storage Backend
 # ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Added
+- Additive LlamaGuard safety classifier (Phase 21.2, landed dark):
+  `SafetyClassifier` (`src/models/safety_classifier.py`) behind the optional
+  `OLLAMA_SAFETY_MODEL` env var. It maps LlamaGuard's S1-S14 hazard categories to
+  empathySync actions - dangerous categories refuse, S11 routes to crisis, and
+  crucially S6 (specialized medical/financial/legal advice) routes to the existing
+  health/money restraint rather than a refusal (the anti-regression finding from
+  the Phase 21.1 evaluation). Additive on top of the base classifier, fails open,
+  and off by default. Unit-tested (34 tests); not yet wired into the request
+  pipeline - integration is a follow-up increment.
+
 ### Changed
 - Schema v3 migration: dropped the dormant `session_intents.user_input` SQLite
   column (`src/utils/database.py`, `_migrate_v2_to_v3`). The write path was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ See `.env.example` for full documentation and defaults.
 - `LLM_CLASSIFICATION_ENABLED` — Enable LLM classifier (default: `true`)
 - `OLLAMA_CLASSIFIER_MODEL` — Dedicated classifier model; falls back to
   `OLLAMA_MODEL` if unset. Smaller models run faster (~9s vs ~19s).
+- `OLLAMA_SAFETY_MODEL` — Optional additive LlamaGuard model (e.g.
+  `llama-guard3:1b`). Off by default. Landed but not yet wired into the pipeline
+  (Phase 21.2).
 
 **Storage:**
 - `USE_SQLITE` — SQLite backend instead of JSON (default: `false`)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ OLLAMA_TEMPERATURE=0.7
 # Optional
 LLM_CLASSIFICATION_ENABLED=true        # Intelligent context-aware classification
 OLLAMA_CLASSIFIER_MODEL=mistral:7b-instruct  # Separate classifier model (faster; falls back to OLLAMA_MODEL)
+# OLLAMA_SAFETY_MODEL=llama-guard3:1b  # Optional additive LlamaGuard layer (off by default; Phase 21.2, not yet wired)
 STORE_CONVERSATIONS=true               # Local storage only
 USE_SQLITE=false                       # SQLite backend (better concurrency)
 ENABLE_DEVICE_LOCK=false               # Multi-device sync safety

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -37,6 +37,11 @@ class Settings:
     # Falls back to OLLAMA_MODEL if not set. Recommended: mistral:7b-instruct
     OLLAMA_CLASSIFIER_MODEL: str = os.getenv("OLLAMA_CLASSIFIER_MODEL", "")
 
+    # Dedicated safety guard model (Phase 21.2, optional, off by default).
+    # When set (e.g. llama-guard3:1b), an additive LlamaGuard layer classifies
+    # input hazards alongside the base classifier. Unset = disabled.
+    OLLAMA_SAFETY_MODEL: str = os.getenv("OLLAMA_SAFETY_MODEL", "")
+
     # LLM Classification (Phase 9)
     # When enabled, uses the Ollama model to intelligently classify messages
     # instead of relying solely on keyword matching

--- a/src/models/safety_classifier.py
+++ b/src/models/safety_classifier.py
@@ -1,0 +1,176 @@
+"""
+LlamaGuard safety classifier (Phase 21.2) - ADDITIVE input-side safety layer.
+
+Runs a dedicated guard model (llama-guard3:1b, chosen in Phase 21.1) alongside
+the existing prompt-engineered RiskClassifier. It is NOT a replacement: the guard
+catches dangerous requests the base classifier can miss, but it is blind to
+fiction / hypothetical framing that the base classifier handles - so both run.
+
+Design constraints, straight from the Phase 21.1 evaluation:
+
+  - Category-mapped, never a blanket block. LlamaGuard reports MLCommons hazard
+    categories S1-S14. The single most important mapping: S6 (specialized
+    medical / financial / legal advice) is an empathySync RESTRAINT domain, not a
+    refusal - every guard false positive in the eval was a health or money
+    question. Treating "unsafe" as a blanket block would regress the assistant
+    into refusing legitimate health questions.
+
+  - Fail-open. This is defense-in-depth on top of an already-safe pipeline
+    (RiskClassifier + mid-stream voice check + post-stream backstop). If the guard
+    model is unset or unreachable, classify() returns ALLOW so the base pipeline
+    still runs. The guard only ADDS refusals; it is never the sole gate.
+
+  - Off by default. Active only when OLLAMA_SAFETY_MODEL is set.
+
+NOTE (Phase 21.2): this module is landed dark. It is unit-tested but not yet wired
+into the request pipeline; mapping SafetyAction into RiskClassifier / the Step 5
+hard-stop is a follow-up increment.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import FrozenSet, Optional
+
+import httpx
+
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SafetyAction(str, Enum):
+    """What empathySync should do with a message, per the guard verdict."""
+
+    ALLOW = "allow"  # no actionable hazard - defer entirely to the base pipeline
+    RESTRAIN = "restrain"  # S6 specialized advice - route via existing restraint, do NOT refuse
+    CRISIS = "crisis"  # S11 suicide & self-harm - route to crisis intervention
+    REFUSE = "refuse"  # dangerous request - map to the 'harmful' hard-stop
+
+
+# MLCommons hazard taxonomy used by Llama Guard 3 (model-card categories S1-S14),
+# mapped to empathySync actions. A category not listed here defaults to REFUSE:
+# a flagged hazard with no empathySync-specific handling is refused, the
+# conservative direction. The health/money false-positive risk is confined to S6,
+# which is handled explicitly below.
+_CATEGORY_ACTION = {
+    "S1": SafetyAction.REFUSE,  # Violent Crimes
+    "S2": SafetyAction.REFUSE,  # Non-Violent Crimes
+    "S3": SafetyAction.REFUSE,  # Sex-Related Crimes
+    "S4": SafetyAction.REFUSE,  # Child Sexual Exploitation
+    "S5": SafetyAction.REFUSE,  # Defamation
+    "S6": SafetyAction.RESTRAIN,  # Specialized Advice (medical/financial/legal) - restraint, NOT refuse
+    "S7": SafetyAction.REFUSE,  # Privacy
+    "S8": SafetyAction.ALLOW,  # Intellectual Property - not an empathySync hazard
+    "S9": SafetyAction.REFUSE,  # Indiscriminate Weapons
+    "S10": SafetyAction.REFUSE,  # Hate
+    "S11": SafetyAction.CRISIS,  # Suicide & Self-Harm - crisis intervention
+    "S12": SafetyAction.REFUSE,  # Sexual Content
+    "S13": SafetyAction.ALLOW,  # Elections - out of scope for a wellness assistant
+    "S14": SafetyAction.ALLOW,  # Code Interpreter Abuse - empathySync runs no code
+}
+
+# Highest-priority action wins when a message trips several categories: life-safety
+# (crisis) over refusal over restraint over allow.
+_ACTION_PRECEDENCE = (
+    SafetyAction.CRISIS,
+    SafetyAction.REFUSE,
+    SafetyAction.RESTRAIN,
+    SafetyAction.ALLOW,
+)
+
+
+@dataclass(frozen=True)
+class GuardVerdict:
+    """Parsed LlamaGuard output: safe flag plus the raw hazard categories."""
+
+    safe: bool
+    categories: FrozenSet[str]
+
+    @property
+    def action(self) -> SafetyAction:
+        if self.safe:
+            return SafetyAction.ALLOW
+        return action_for_categories(self.categories)
+
+
+def action_for_categories(categories) -> SafetyAction:
+    """Reduce a set of hazard categories to a single SafetyAction by precedence."""
+    actions = {_CATEGORY_ACTION.get(c.upper(), SafetyAction.REFUSE) for c in categories}
+    for action in _ACTION_PRECEDENCE:
+        if action in actions:
+            return action
+    return SafetyAction.ALLOW
+
+
+def parse_guard_response(raw: str) -> GuardVerdict:
+    """Parse LlamaGuard's text output.
+
+    The model answers with 'safe', or 'unsafe' followed by the violated category
+    codes (e.g. 'unsafe\\nS6' or 'unsafe\\nS1,S10'). Anything that is not a clear
+    'unsafe' verdict is treated as safe.
+    """
+    lines = [ln.strip() for ln in (raw or "").splitlines() if ln.strip()]
+    if not lines or lines[0].lower() != "unsafe":
+        return GuardVerdict(safe=True, categories=frozenset())
+
+    codes = set()
+    for line in lines[1:]:
+        for token in line.replace(",", " ").split():
+            token = token.upper()
+            if token.startswith("S") and token[1:].isdigit():
+                codes.add(token)
+    return GuardVerdict(safe=False, categories=frozenset(codes))
+
+
+class SafetyClassifier:
+    """Additive LlamaGuard layer over the base classifier. Off unless a model is set.
+
+    Args:
+        model: guard model name (default: settings.OLLAMA_SAFETY_MODEL).
+        http_client: injectable httpx.Client for testability. If None, the shared
+                     module-level client is used.
+    """
+
+    def __init__(self, model: Optional[str] = None, http_client: Optional[httpx.Client] = None):
+        self.model = model if model is not None else settings.OLLAMA_SAFETY_MODEL
+        self._http_client = http_client
+        self.chat_url = f"{settings.OLLAMA_HOST}/api/chat"
+
+    @property
+    def enabled(self) -> bool:
+        """The guard runs only when a model name is configured."""
+        return bool(self.model)
+
+    @property
+    def http_client(self) -> httpx.Client:
+        if self._http_client is not None:
+            return self._http_client
+        from utils.http_client import get_http_client
+
+        return get_http_client()
+
+    def classify(self, message: str) -> SafetyAction:
+        """Return the SafetyAction for a user message.
+
+        Fail-open: if the guard is disabled or the call fails, returns ALLOW so the
+        base pipeline remains authoritative. The guard never becomes the sole gate.
+        """
+        if not self.enabled:
+            return SafetyAction.ALLOW
+
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": message}],
+            "stream": False,
+            "options": {"temperature": 0.0},
+        }
+        try:
+            response = self.http_client.post(self.chat_url, json=payload, timeout=30)
+            response.raise_for_status()
+            raw = response.json().get("message", {}).get("content", "")
+        except Exception as exc:  # fail-open - an additive layer must never break the pipeline
+            logger.warning("safety guard unavailable, failing open (ALLOW): %s", exc)
+            return SafetyAction.ALLOW
+
+        return parse_guard_response(raw).action

--- a/tests/test_safety_classifier.py
+++ b/tests/test_safety_classifier.py
@@ -1,0 +1,148 @@
+"""
+Tests for the additive LlamaGuard safety classifier (Phase 21.2).
+
+All tests run offline - the guard's HTTP call is mocked - so the suite needs no
+Ollama. Covers response parsing, category-to-action mapping (including the
+critical S6 -> RESTRAIN anti-regression rule and multi-category precedence), and
+the classifier's disabled / fail-open behavior.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from models.safety_classifier import (  # noqa: E402
+    GuardVerdict,
+    SafetyAction,
+    SafetyClassifier,
+    action_for_categories,
+    parse_guard_response,
+)
+
+
+class TestParseGuardResponse:
+    def test_safe(self):
+        v = parse_guard_response("safe")
+        assert v.safe is True
+        assert v.categories == frozenset()
+
+    def test_safe_case_and_whitespace_insensitive(self):
+        assert parse_guard_response("  Safe\n").safe is True
+
+    def test_unsafe_single_category(self):
+        v = parse_guard_response("unsafe\nS6")
+        assert v.safe is False
+        assert v.categories == frozenset({"S6"})
+
+    def test_unsafe_multi_category_comma(self):
+        v = parse_guard_response("unsafe\nS1,S10")
+        assert v.categories == frozenset({"S1", "S10"})
+
+    def test_unsafe_multi_category_newlines(self):
+        v = parse_guard_response("unsafe\nS1\nS9")
+        assert v.categories == frozenset({"S1", "S9"})
+
+    def test_unsafe_lowercase_codes_normalized(self):
+        assert parse_guard_response("unsafe\ns6").categories == frozenset({"S6"})
+
+    def test_empty_and_garbage_are_safe(self):
+        assert parse_guard_response("").safe is True
+        assert parse_guard_response(None).safe is True
+        assert parse_guard_response("I think that's fine").safe is True
+
+    def test_unsafe_without_codes_is_unsafe_but_empty(self):
+        v = parse_guard_response("unsafe")
+        assert v.safe is False
+        assert v.categories == frozenset()
+
+
+class TestActionMapping:
+    def test_s6_specialized_advice_is_restrain_not_refuse(self):
+        # The Phase 21.1 anti-regression rule: health/money questions must not be refused.
+        assert action_for_categories({"S6"}) == SafetyAction.RESTRAIN
+
+    def test_s11_self_harm_is_crisis(self):
+        assert action_for_categories({"S11"}) == SafetyAction.CRISIS
+
+    @pytest.mark.parametrize("cat", ["S1", "S2", "S3", "S4", "S5", "S7", "S9", "S10", "S12"])
+    def test_dangerous_categories_refuse(self, cat):
+        assert action_for_categories({cat}) == SafetyAction.REFUSE
+
+    @pytest.mark.parametrize("cat", ["S8", "S13", "S14"])
+    def test_out_of_scope_categories_allow(self, cat):
+        assert action_for_categories({cat}) == SafetyAction.ALLOW
+
+    def test_unknown_category_defaults_to_refuse(self):
+        assert action_for_categories({"S99"}) == SafetyAction.REFUSE
+
+    def test_empty_categories_allow(self):
+        assert action_for_categories(set()) == SafetyAction.ALLOW
+
+    def test_precedence_crisis_over_refuse(self):
+        assert action_for_categories({"S1", "S11"}) == SafetyAction.CRISIS
+
+    def test_precedence_refuse_over_restrain(self):
+        assert action_for_categories({"S1", "S6"}) == SafetyAction.REFUSE
+
+    def test_precedence_restrain_over_allow(self):
+        assert action_for_categories({"S6", "S8"}) == SafetyAction.RESTRAIN
+
+
+class TestGuardVerdictAction:
+    def test_safe_verdict_allows(self):
+        assert GuardVerdict(safe=True, categories=frozenset()).action == SafetyAction.ALLOW
+
+    def test_unsafe_verdict_maps_categories(self):
+        assert (
+            GuardVerdict(safe=False, categories=frozenset({"S6"})).action == SafetyAction.RESTRAIN
+        )
+
+
+def _mock_client(content=None, raises=None):
+    """An httpx-like client whose post() returns a guard response, or raises."""
+    client = Mock()
+    if raises is not None:
+        client.post.side_effect = raises
+        return client
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json = Mock(return_value={"message": {"content": content}})
+    client.post = Mock(return_value=response)
+    return client
+
+
+class TestSafetyClassifier:
+    def test_disabled_when_no_model_returns_allow_without_http(self):
+        client = _mock_client(content="unsafe\nS1")
+        clf = SafetyClassifier(model="", http_client=client)
+        assert clf.enabled is False
+        assert clf.classify("anything") == SafetyAction.ALLOW
+        client.post.assert_not_called()
+
+    def test_enabled_s6_maps_to_restrain(self):
+        client = _mock_client(content="unsafe\nS6")
+        clf = SafetyClassifier(model="llama-guard3:1b", http_client=client)
+        assert clf.enabled is True
+        assert clf.classify("is 800mg of ibuprofen too much?") == SafetyAction.RESTRAIN
+
+    def test_enabled_safe_response_allows(self):
+        clf = SafetyClassifier(model="llama-guard3:1b", http_client=_mock_client(content="safe"))
+        assert clf.classify("how do I write a cover letter?") == SafetyAction.ALLOW
+
+    def test_fail_open_on_http_error(self):
+        client = _mock_client(raises=RuntimeError("connection refused"))
+        clf = SafetyClassifier(model="llama-guard3:1b", http_client=client)
+        assert clf.classify("anything") == SafetyAction.ALLOW
+
+    def test_calls_chat_endpoint_with_model(self):
+        client = _mock_client(content="safe")
+        clf = SafetyClassifier(model="llama-guard3:1b", http_client=client)
+        clf.classify("hello")
+        args, kwargs = client.post.call_args
+        assert args[0].endswith("/api/chat")
+        assert kwargs["json"]["model"] == "llama-guard3:1b"
+        assert kwargs["json"]["messages"][0]["content"] == "hello"


### PR DESCRIPTION
## Summary

First increment of Phase 21.2: an additive LlamaGuard safety classifier, landed **dark** (unit-tested, not yet wired into the request pipeline). It de-risks the hardest design decision - the S1-S14 category mapping - as a tested unit before it ever touches the streaming path.

`SafetyClassifier` (`src/models/safety_classifier.py`) runs behind the optional `OLLAMA_SAFETY_MODEL` env var and maps LlamaGuard's MLCommons hazard categories to empathySync actions:

- dangerous categories (S1-S5, S7, S9, S10, S12) -> **REFUSE** (the existing `harmful` hard-stop)
- S11 (suicide & self-harm) -> **CRISIS** (the existing crisis path)
- **S6 (specialized medical/financial/legal advice) -> RESTRAIN** - routes to the existing health/money restraint, *not* a refusal. This is the Phase 21.1 anti-regression finding: every guard false positive in the eval was a health or money question, so a blanket "unsafe = block" would regress into refusing legitimate health questions.
- out-of-scope (S8 IP, S13 elections, S14 code) -> **ALLOW**; unknown codes default to REFUSE; multi-category messages resolve by precedence (crisis > refuse > restrain > allow).

Design guarantees: **additive** over the base classifier (it only adds refusals; the base pipeline stays authoritative), **fails open** if the guard is unset or unreachable, and **off by default**.

## Changes

- `src/models/safety_classifier.py` - new `SafetyClassifier`, `SafetyAction`, `GuardVerdict`, `parse_guard_response`, `action_for_categories`.
- `src/config/settings.py`, `.env.example`, `README.md`, `CLAUDE.md` - document the new `OLLAMA_SAFETY_MODEL` env var (per MERGE_CHECKLIST new-env-var row).
- `tests/test_safety_classifier.py` - 34 offline tests (no Ollama).
- `CHANGELOG.md` - `[Unreleased]` entry.

## Related Issues

Phase 21.2 (issue #125 was auto-closed by the v1.12.0 release; this is follow-on work).

## Testing

- `pytest tests/ -m "not conversation"` - **1104 passed** (1070 + 34 new), coverage 66% (gate 50%).
- `black --check` and `flake8` clean (pre-commit hooks passed on push).
- Domain accuracy eval not applicable: the module touches no classification code path and is not wired into the pipeline, so there is no affected domain.
- All guard behavior is unit-tested offline via an injected mock HTTP client, including the S6->RESTRAIN rule, multi-category precedence, disabled-by-default, and fail-open on error.
