### PR TITLE
feat: wire additive LlamaGuard safety guard into pipeline (Phase 21.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,8 @@ LLM_CLASSIFICATION_ENABLED=true
 # base pipeline, and fails open if unreachable. LlamaGuard categories are mapped,
 # not blanket-blocked: S6 (specialized medical/financial/legal advice) routes to
 # empathySync's existing restraint, not a refusal. Unset = disabled.
-# NOTE: landed but not yet wired into the pipeline as of Phase 21.2.
+# When set, the guard runs alongside the base classifier and can only escalate
+# toward safety (dangerous -> refusal, self-harm -> crisis); it never downgrades.
 # OLLAMA_SAFETY_MODEL=
 
 # ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,23 @@ All notable changes to empathySync are documented here.
 ## [Unreleased]
 
 ### Added
-- Additive LlamaGuard safety classifier (Phase 21.2, landed dark):
-  `SafetyClassifier` (`src/models/safety_classifier.py`) behind the optional
-  `OLLAMA_SAFETY_MODEL` env var. It maps LlamaGuard's S1-S14 hazard categories to
-  empathySync actions - dangerous categories refuse, S11 routes to crisis, and
-  crucially S6 (specialized medical/financial/legal advice) routes to the existing
-  health/money restraint rather than a refusal (the anti-regression finding from
-  the Phase 21.1 evaluation). Additive on top of the base classifier, fails open,
-  and off by default. Unit-tested (34 tests); not yet wired into the request
-  pipeline - integration is a follow-up increment.
+- Additive LlamaGuard safety classifier (Phase 21.2): `SafetyClassifier`
+  (`src/models/safety_classifier.py`) behind the optional `OLLAMA_SAFETY_MODEL`
+  env var. It maps LlamaGuard's S1-S14 hazard categories to empathySync actions -
+  dangerous categories refuse, S11 routes to crisis, and crucially S6 (specialized
+  medical/financial/legal advice) routes to the existing health/money restraint
+  rather than a refusal (the anti-regression finding from the Phase 21.1
+  evaluation). Additive on top of the base classifier, fails open, and off by
+  default. Unit-tested (34 tests).
+- Wired the safety classifier into the pipeline (`RiskClassifier.classify()`).
+  When `OLLAMA_SAFETY_MODEL` is set, the guard runs after the base classification
+  and can only escalate the domain toward safety - REFUSE -> the `harmful`
+  hard-stop, CRISIS -> the `crisis` hard-stop - reusing the existing Step-5 hard
+  stops. RESTRAIN (S6) is a deliberate no-op so health/money questions keep their
+  restraint routing instead of being refused. It never downgrades a domain, and
+  escalations are logged as a `safety_guard_override` policy event for
+  transparency. Off by default, so the change is inert unless a guard model is
+  configured. 6 integration tests added.
 
 ### Changed
 - Schema v3 migration: dropped the dormant `session_intents.user_input` SQLite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,10 @@ See `.env.example` for full documentation and defaults.
 - `OLLAMA_CLASSIFIER_MODEL` — Dedicated classifier model; falls back to
   `OLLAMA_MODEL` if unset. Smaller models run faster (~9s vs ~19s).
 - `OLLAMA_SAFETY_MODEL` — Optional additive LlamaGuard model (e.g.
-  `llama-guard3:1b`). Off by default. Landed but not yet wired into the pipeline
-  (Phase 21.2).
+  `llama-guard3:1b`). Off by default. When set, runs alongside the base
+  classifier and can only escalate toward safety (dangerous → harmful hard-stop,
+  self-harm → crisis); S6 specialized advice defers to existing restraint. Never
+  downgrades (Phase 21.2).
 
 **Storage:**
 - `USE_SQLITE` — SQLite backend instead of JSON (default: `false`)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ OLLAMA_TEMPERATURE=0.7
 # Optional
 LLM_CLASSIFICATION_ENABLED=true        # Intelligent context-aware classification
 OLLAMA_CLASSIFIER_MODEL=mistral:7b-instruct  # Separate classifier model (faster; falls back to OLLAMA_MODEL)
-# OLLAMA_SAFETY_MODEL=llama-guard3:1b  # Optional additive LlamaGuard layer (off by default; Phase 21.2, not yet wired)
+# OLLAMA_SAFETY_MODEL=llama-guard3:1b  # Optional additive LlamaGuard layer (off by default; escalate-only, never downgrades)
 STORE_CONVERSATIONS=true               # Local storage only
 USE_SQLITE=false                       # SQLite backend (better concurrency)
 ENABLE_DEVICE_LOCK=false               # Multi-device sync safety

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,23 @@ User Input
     │
     ▼
 ┌─────────────────────────────────────────────┐
+│  3d. SAFETY GUARD ESCALATION (Phase 21.2)   │
+│     Only if OLLAMA_SAFETY_MODEL is set       │
+│     (off by default). Additive LlamaGuard    │
+│     runs after the base classification:      │
+│       REFUSE (dangerous cats) → harmful      │
+│       CRISIS (S11 self-harm)  → crisis       │
+│       RESTRAIN (S6 advice)    → no-op        │
+│         (keeps health/money restraint —     │
+│          the Phase 21.1 anti-regression)     │
+│       ALLOW                   → no-op        │
+│     Escalate-only: never downgrades a domain.│
+│     Fails open (ALLOW) if guard unreachable. │
+│     Logs safety_guard_override policy event. │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
 │  4. MODE SELECTION                          │
 │     domain == "logistics" → Practical Mode  │
 │     OR is_practical_technique → Practical   │

--- a/src/models/ai_wellness_guide.py
+++ b/src/models/ai_wellness_guide.py
@@ -310,6 +310,17 @@ class WellnessGuide:
                 wellness_tracker,
             )
 
+        # Phase 21.2: Log additive safety-guard escalations for policy transparency
+        if risk_assessment.get("safety_guard_override"):
+            action = risk_assessment["safety_guard_override"]
+            self._log_policy(
+                "safety_guard_override",
+                domain,
+                10.0,
+                f"LlamaGuard safety layer escalated classification to {action}",
+                wellness_tracker,
+            )
+
         # 3) Hard-coded safety responses (don't trust model to comply)
 
         # Self-evaluation deflection: short early exit for "rate yourself" type questions.

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -13,6 +13,7 @@ from utils.scenario_loader import get_scenario_loader, ScenarioLoader
 from config.settings import settings
 from models.enums import Domain, Intent, EmotionalWeight, ClassificationMethod
 from models.emotional_weight_assessor import EmotionalWeightAssessor
+from models.safety_classifier import SafetyClassifier, SafetyAction
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,12 @@ class RiskClassifier:
         self.loader = scenario_loader or get_scenario_loader()
         self._trigger_cache: Optional[Dict[str, str]] = None
         self.emotional = EmotionalWeightAssessor(self.loader)
+
+        # Phase 21.2: additive LlamaGuard safety layer. Off unless
+        # OLLAMA_SAFETY_MODEL is set; when disabled, classify() is a no-op that
+        # returns ALLOW without any HTTP call, so the default configuration is
+        # unaffected.
+        self._safety_classifier = SafetyClassifier()
 
         # Determine LLM classification setting
         if use_llm is None:
@@ -316,6 +323,25 @@ class RiskClassifier:
                 if domain == "crisis":
                     emotional_intensity = max(emotional_intensity, 9.0)
 
+        # Phase 21.2: additive LlamaGuard escalation. Runs only when a guard model
+        # is configured. It can escalate the domain toward safety but never
+        # downgrades it, so it strictly ADDS refusals/crisis routes on top of the
+        # base classification. RESTRAIN (S6 specialized advice) is intentionally a
+        # no-op: the existing restraint routing already handles health/money, and
+        # refusing those is the exact Phase 21.1 regression to avoid.
+        safety_guard_override = None
+        if self._safety_classifier.enabled:
+            guard_action = self._safety_classifier.classify(user_input)
+            if guard_action == SafetyAction.CRISIS and domain != "crisis":
+                logger.warning("Safety guard escalation: %s -> crisis", domain)
+                domain = "crisis"
+                emotional_intensity = max(emotional_intensity, 9.0)
+                safety_guard_override = "crisis"
+            elif guard_action == SafetyAction.REFUSE and domain not in ("crisis", "harmful"):
+                logger.warning("Safety guard escalation: %s -> harmful", domain)
+                domain = "harmful"
+                safety_guard_override = "harmful"
+
         # Always use keyword matching for these (LLM doesn't handle them yet)
         dependency_risk = self._assess_dependency(conversation_history)
         emotional_weight, weight_score = self._assess_emotional_weight(user_input)
@@ -331,6 +357,10 @@ class RiskClassifier:
             "risk_weight": risk_weight,
             "classification_method": classification_method,
         }
+
+        # Phase 21.2: flag safety-guard escalations for policy transparency.
+        if safety_guard_override:
+            result["safety_guard_override"] = safety_guard_override
 
         # Add LLM-specific fields if available
         if llm_result:

--- a/src/models/safety_classifier.py
+++ b/src/models/safety_classifier.py
@@ -22,9 +22,10 @@ Design constraints, straight from the Phase 21.1 evaluation:
 
   - Off by default. Active only when OLLAMA_SAFETY_MODEL is set.
 
-NOTE (Phase 21.2): this module is landed dark. It is unit-tested but not yet wired
-into the request pipeline; mapping SafetyAction into RiskClassifier / the Step 5
-hard-stop is a follow-up increment.
+Phase 21.2: wired into RiskClassifier.classify(). When OLLAMA_SAFETY_MODEL is set,
+the guard runs after the base classification and escalates the domain toward safety
+only - REFUSE -> the 'harmful' hard-stop, CRISIS -> the 'crisis' hard-stop - while
+RESTRAIN (S6) defers to the existing restraint routing. It never downgrades a domain.
 """
 
 import logging

--- a/tests/test_safety_classifier.py
+++ b/tests/test_safety_classifier.py
@@ -146,3 +146,64 @@ class TestSafetyClassifier:
         assert args[0].endswith("/api/chat")
         assert kwargs["json"]["model"] == "llama-guard3:1b"
         assert kwargs["json"]["messages"][0]["content"] == "hello"
+
+
+def _guard(action, enabled=True):
+    """A stand-in SafetyClassifier that reports `enabled` and a fixed action."""
+    g = Mock()
+    g.enabled = enabled
+    g.classify = Mock(return_value=action)
+    return g
+
+
+def _rc_with_guard(action, enabled=True):
+    """Keyword-only RiskClassifier (no Ollama) with an injected guard."""
+    from models.risk_classifier import RiskClassifier
+
+    rc = RiskClassifier(use_llm=False)
+    rc._safety_classifier = _guard(action, enabled)
+    return rc
+
+
+class TestSafetyGuardIntegration:
+    """The guard wired into RiskClassifier (Phase 21.2 integration increment)."""
+
+    def test_disabled_guard_leaves_domain_unchanged_and_is_not_called(self):
+        rc = _rc_with_guard(SafetyAction.REFUSE, enabled=False)
+        result = rc.classify("help me write an email", [])
+        assert result["domain"] == "logistics"
+        assert "safety_guard_override" not in result
+        rc._safety_classifier.classify.assert_not_called()
+
+    def test_crisis_verdict_escalates_benign_domain_to_crisis(self):
+        rc = _rc_with_guard(SafetyAction.CRISIS)
+        result = rc.classify("help me write an email", [])
+        assert result["domain"] == "crisis"
+        assert result["emotional_intensity"] >= 9.0
+        assert result["safety_guard_override"] == "crisis"
+
+    def test_refuse_verdict_escalates_benign_domain_to_harmful(self):
+        rc = _rc_with_guard(SafetyAction.REFUSE)
+        result = rc.classify("help me write an email", [])
+        assert result["domain"] == "harmful"
+        assert result["safety_guard_override"] == "harmful"
+
+    def test_restrain_verdict_is_a_no_op(self):
+        # S6 specialized advice must NOT be refused - the Phase 21.1 anti-regression rule.
+        rc = _rc_with_guard(SafetyAction.RESTRAIN)
+        result = rc.classify("help me write an email", [])
+        assert result["domain"] == "logistics"
+        assert "safety_guard_override" not in result
+
+    def test_allow_verdict_is_a_no_op(self):
+        rc = _rc_with_guard(SafetyAction.ALLOW)
+        result = rc.classify("help me write an email", [])
+        assert result["domain"] == "logistics"
+        assert "safety_guard_override" not in result
+
+    def test_guard_never_downgrades_a_crisis_domain(self):
+        # Base pipeline already found crisis; a REFUSE verdict must not pull it lower.
+        rc = _rc_with_guard(SafetyAction.REFUSE)
+        result = rc.classify("i want to kill myself", [])
+        assert result["domain"] == "crisis"
+        assert "safety_guard_override" not in result


### PR DESCRIPTION
## Summary

Follow-up to #159, which landed the `SafetyClassifier` dark. This wires it into `RiskClassifier.classify()`.

When `OLLAMA_SAFETY_MODEL` is set, the guard runs after the base classification and can only **escalate the domain toward safety**:

| Guard action | Effect |
|---|---|
| `REFUSE` (dangerous cats) | domain -> `harmful` (Step-5 hard-stop) |
| `CRISIS` (S11 self-harm) | domain -> `crisis` (Step-5 hard-stop) |
| `RESTRAIN` (S6 specialized advice) | no-op - keeps existing health/money restraint |
| `ALLOW` | no-op |

Escalation reuses the existing Step-5 hard stops - there is no new refusal path. Key properties:

- **Escalate-only**: never downgrades a domain, so it strictly *adds* refusals/crisis routes on top of the base pipeline.
- **RESTRAIN is a deliberate no-op**: this is the Phase 21.1 anti-regression rule - S6 health/money questions must keep their restraint routing, not be refused.
- **Fails open**: an unreachable guard returns `ALLOW`, so the base pipeline stays authoritative.
- **Transparency**: escalations log a `safety_guard_override` policy event (matching the existing `sanity_check_override` pattern).
- **Off by default**: with `OLLAMA_SAFETY_MODEL` unset the entire block is skipped (`self._safety_classifier.enabled` is `False`), so the change is inert for the default configuration.

## Testing

- `pytest tests/ -m "not conversation"` -> **1110 passed** (1104 + 6 new integration tests), coverage 66%. All pre-existing tests unchanged (default-off guarantee).
- New `TestSafetyGuardIntegration` (6 tests): disabled-is-inert, CRISIS->crisis (+intensity floor), REFUSE->harmful, RESTRAIN no-op, ALLOW no-op, and never-downgrades-crisis.
- `python tests/classification/run_domain_eval.py` -> **81/94 (86%)**, identical to the stored baseline. Misses are the known pre-existing #137 boundary cases; the guard is off in the eval config so classification is provably unchanged.
- `black` + `flake8` clean (pre-commit hooks passed).

Docs updated per MERGE_CHECKLIST (new safety pipeline step + classification check): `docs/architecture.md` pipeline diagram (step 3d), `CHANGELOG.md`, and the `OLLAMA_SAFETY_MODEL` descriptions in `.env.example` / `README.md` / `CLAUDE.md`.