### PR TITLE
feat: startup health check for the safety guard (Phase 21.2 gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to empathySync are documented here.
   section (harm-recall criterion, distinct from the classifier distress-recall
   list), and added `tests/test_safety_guard_integration.py` (conversation-tier, 3
   tests, skipped when the guard model is absent) to lock in both properties.
+- Startup health check for the safety guard (`check_safety_guard` in
+  `src/utils/health_check.py`). When `OLLAMA_SAFETY_MODEL` is set but the model is
+  not pulled, it warns that the guard is inactive and failing open on every
+  message - previously that misconfiguration was silent. Non-critical (the guard
+  fails open by design, so it never blocks startup). 5 offline tests.
 
 ### Changed
 - Schema v3 migration: dropped the dormant `session_intents.user_input` SQLite

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,7 +135,8 @@ classification - the main conversation model stays unchanged.
 - [x] Safety model output mapped to empathySync's `domain` (REFUSE→harmful, CRISIS→crisis) (#160)
 - [x] Fallback: if safety model unavailable, guard fails open (ALLOW) and the existing
   prompt-engineered classifier remains authoritative (#159)
-- [ ] Health check warns if safety model is configured but unreachable
+- [x] Health check warns if safety model is configured but unreachable
+  (`check_safety_guard` in `src/utils/health_check.py`; non-critical since the guard fails open)
 - [ ] Stretch: evaluate running the guard model over the *output* stream as well - the
   current mid-stream buffer scans for manipulative-voice patterns, not dangerous content
 

--- a/src/utils/health_check.py
+++ b/src/utils/health_check.py
@@ -203,6 +203,71 @@ def check_classifier_model() -> HealthStatus:
         )
 
 
+def check_safety_guard() -> HealthStatus:
+    """Check the optional LlamaGuard safety model (Phase 21.2).
+
+    Non-critical: the guard is additive and fails open, so the base pipeline
+    stays authoritative whether or not it is reachable. But if it is configured
+    and *not* pulled, warn - otherwise the operator believes a guard is running
+    when every message is silently failing open to ALLOW.
+    """
+    guard_model = settings.OLLAMA_SAFETY_MODEL
+    if not guard_model:
+        return HealthStatus(
+            name="Safety Guard",
+            ok=True,
+            message="Disabled (OLLAMA_SAFETY_MODEL not set)",
+            critical=False,
+        )
+
+    try:
+        client = get_http_client()
+        response = client.get(f"{settings.OLLAMA_HOST}/api/tags", timeout=5)
+        if response.status_code != 200:
+            return HealthStatus(
+                name="Safety Guard",
+                ok=True,
+                message=f"Cannot verify `{guard_model}` - guard fails open until reachable",
+                critical=False,
+            )
+
+        available_models = [m.get("name", "") for m in response.json().get("models", [])]
+        model_found = any(
+            m == guard_model or m.startswith(f"{guard_model}:") for m in available_models
+        )
+
+        if model_found:
+            return HealthStatus(
+                name="Safety Guard",
+                ok=True,
+                message=f"`{guard_model}` available",
+                critical=False,
+            )
+
+        logger.warning(
+            f"Safety model '{guard_model}' is configured but not pulled - the guard is "
+            f"failing open (ALLOW) on every message. Run: ollama pull {guard_model}"
+        )
+        return HealthStatus(
+            name="Safety Guard",
+            ok=True,
+            message=f"Configured `{guard_model}` not found - guard inactive (failing open)",
+            critical=False,
+            details=(
+                f"`OLLAMA_SAFETY_MODEL={guard_model}` is set but the model is not pulled, so the "
+                "additive safety layer is doing nothing. The base pipeline remains active.\n\n"
+                f"To activate the guard: `ollama pull {guard_model}`"
+            ),
+        )
+    except Exception:
+        return HealthStatus(
+            name="Safety Guard",
+            ok=True,
+            message=f"Cannot verify `{guard_model}` - guard fails open until reachable",
+            critical=False,
+        )
+
+
 def check_data_directory() -> HealthStatus:
     """Check if the data directory exists and is writable."""
     data_dir = settings.DATA_DIR
@@ -325,6 +390,7 @@ def run_health_checks() -> List[HealthStatus]:
         check_ollama_model(),
         check_classifier_model(),
         check_model_safety_tier(),
+        check_safety_guard(),
         check_data_directory(),
     ]
 

--- a/tests/test_health_check_safety_guard.py
+++ b/tests/test_health_check_safety_guard.py
@@ -1,0 +1,84 @@
+"""
+Tests for the safety-guard startup health check (Phase 21.2 follow-up).
+
+Offline - the Ollama /api/tags call is mocked. Verifies that a configured but
+unpulled guard model is surfaced as a warning (the gap this check closes), while
+a disabled or present guard reports cleanly. The check is always non-critical:
+the guard fails open, so it must never block startup.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from config.settings import settings  # noqa: E402
+from utils.health_check import check_safety_guard  # noqa: E402
+
+
+def _client_with_models(names):
+    client = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json = Mock(return_value={"models": [{"name": n} for n in names]})
+    client.get = Mock(return_value=response)
+    return client
+
+
+@pytest.fixture
+def guard_model(monkeypatch):
+    """Set OLLAMA_SAFETY_MODEL for the duration of a test, restored after."""
+
+    def _set(value):
+        monkeypatch.setattr(settings, "OLLAMA_SAFETY_MODEL", value)
+
+    return _set
+
+
+class TestCheckSafetyGuard:
+    def test_disabled_when_unset(self, guard_model):
+        guard_model("")
+        status = check_safety_guard()
+        assert status.ok is True
+        assert status.critical is False
+        assert "Disabled" in status.message
+
+    def test_available_when_pulled(self, guard_model):
+        guard_model("llama-guard3:1b")
+        client = _client_with_models(["gemma3:12b", "llama-guard3:1b"])
+        with patch("utils.health_check.get_http_client", return_value=client):
+            status = check_safety_guard()
+        assert status.ok is True
+        assert "available" in status.message
+
+    def test_configured_but_missing_warns(self, guard_model):
+        guard_model("llama-guard3:1b")
+        client = _client_with_models(["gemma3:12b"])  # guard not pulled
+        with patch("utils.health_check.get_http_client", return_value=client):
+            status = check_safety_guard()
+        # Non-critical (fails open), but surfaces the misconfiguration.
+        assert status.ok is True
+        assert status.critical is False
+        assert "not found" in status.message
+        assert "ollama pull llama-guard3:1b" in status.details
+
+    def test_matches_tagged_variant(self, guard_model):
+        # Configured without a tag should still match a tagged model name.
+        guard_model("llama-guard3")
+        client = _client_with_models(["llama-guard3:1b"])
+        with patch("utils.health_check.get_http_client", return_value=client):
+            status = check_safety_guard()
+        assert "available" in status.message
+
+    def test_fails_open_on_http_error(self, guard_model):
+        guard_model("llama-guard3:1b")
+        client = Mock()
+        client.get = Mock(side_effect=RuntimeError("connection refused"))
+        with patch("utils.health_check.get_http_client", return_value=client):
+            status = check_safety_guard()
+        assert status.ok is True
+        assert status.critical is False
+        assert "Cannot verify" in status.message


### PR DESCRIPTION
## Summary

Closes the last open Phase 21.2 checklist item (deliberately left out of the #161 eval PR to keep scope clean).

When `OLLAMA_SAFETY_MODEL` is set but the model isn't pulled, the guard was silently failing open (`ALLOW`) on every message - the operator believed a guard was running when it wasn't. `check_safety_guard()` now surfaces that at startup:

| State | Report |
|---|---|
| unset | `Disabled` |
| pulled | `` `<model>` available `` |
| configured but missing | warns `guard inactive (failing open)` + `ollama pull` instructions |
| Ollama unreachable | `Cannot verify - guard fails open until reachable` |

**Non-critical in every case** - the guard fails open by design, so this check must never block startup. It only informs.

## Testing

- `tests/test_health_check_safety_guard.py` - 5 offline tests (mocked `/api/tags`): disabled, available, configured-but-missing (the warn case), tagged-variant match, and http-error fail-open.
- `pytest tests/ -m "not conversation"` → **1115 passed** (1110 + 5), coverage 66%.
- Verified live: pulled model → "available"; unpulled name → warns "failing open".
- `black` + `flake8` clean.