### PR TITLE
fix: spirituality domain-routing corrections (Phase 21.4, #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ All notable changes to empathySync are documented here.
   not pulled, it warns that the guard is inactive and failing open on every
   message - previously that misconfiguration was silent. Non-critical (the guard
   fails open by design, so it never blocks startup). 5 offline tests.
+- Phase 21.4 spirituality routing corrections (#137). Religious framing (deity
+  names, clergy, rulings like "haram"/"god's will") is high-precision but
+  low-volume, so it ties with and loses to the relational/emotional surface of the
+  same sentence, and every other override was one-directional - so a religious
+  question the LLM read as `relationships` (e.g. "is it haram to leave my
+  marriage") silently lost its spirituality restraint. Three coordinated fixes in
+  `src/models/risk_classifier.py` + `scenarios/domains/spirituality.yaml`: added
+  the missing high-signal triggers (`haram`, `halal`, `god's will`, `baptised`);
+  a keyword tie-break that resolves ties toward spirituality; and a symmetric
+  specific→spirituality override (runs regardless of LLM confidence; never touches
+  crisis/harmful). Domain eval 81/94 → **83/94** (spirituality 10/13 → 12/13), no
+  net regression. 11 deterministic tests (`tests/test_spirituality_routing.py`).
+
+### Fixed
+- `cult` was a bare-substring trigger that false-matched "diffiCULT", "CULTure",
+  "CULTivate", "ocCULT" - routing ordinary messages to `spirituality`. Replaced
+  with collision-safe forms (`cult leader`, `cult member`, `cult survivor`, `cult
+  following`). Latent since the trigger was added; surfaced by the Phase 21.4
+  spirituality override, which now trusts keyword spirituality signals.
 
 ### Changed
 - Schema v3 migration: dropped the dormant `session_intents.user_input` SQLite

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,12 +167,19 @@ whichever label the LLM reaches first wins forever. Measured consequences:
   short-continuation LLM-skip plus the practical empty-generation fallback.
 
 **Implementation**:
-- [ ] Symmetric specific→specific override: when keywords find a *different* sensitive
-      domain than the LLM's sensitive-domain label, resolve by keyword-priority rather
-      than always keeping the LLM label
+- [x] Symmetric specific→spirituality override: when keyword detection finds spirituality
+      but the LLM chose a different domain, spirituality wins (runs regardless of confidence;
+      never overrides crisis/harmful). Investigation finding: the ROADMAP premise was
+      incomplete - keyword detection *also* lost the flagship cases (haram/rabbi tie-broke to
+      relationships; god's will/baptised weren't triggers at all), so the fix is three parts:
+      missing high-signal triggers + a keyword tie-break toward spirituality + the override.
+      Scoped to spirituality-wins (the measured gravity-well victim) to bound regression risk.
 - [ ] Contentless-continuation fallback: short continuations with no domain signal
-      inherit session context instead of defaulting to logistics
-- [ ] Re-run domain eval; the four known spirituality boundary misses are the acceptance test
+      inherit session context instead of defaulting to logistics (#135 residual - deferred,
+      separate from the spirituality gravity well)
+- [x] Re-ran domain eval: 81/94 → 83/94; the four spirituality boundary misses (haram, rabbi,
+      god's will, baptised) are deterministically fixed. Also fixed a latent `cult` substring
+      bug (matched "difficult"/"culture") the override surfaced.
 
 **Files to create**:
 - `src/models/safety_classifier.py` - LlamaGuard/WildGuard adapter implementing the same

--- a/TESTING_CHECKLIST.md
+++ b/TESTING_CHECKLIST.md
@@ -26,8 +26,8 @@ pytest tests/test_restraint_memory.py -v
 python scripts/check_version.py
 ```
 
-Expected: `pytest` all green, domain eval at or above the 86% baseline
-(81/94 on mistral:7b-instruct), version check passes.
+Expected: `pytest` all green, domain eval at or above the 88% baseline
+(83/94 on mistral:7b-instruct, post Phase 21.4), version check passes.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,22 @@ User Input
     │
     ▼
 ┌─────────────────────────────────────────────┐
+│  3b'. SPIRITUALITY OVERRIDE (Phase 21.4)    │
+│     Religious framing (deity, clergy,       │
+│     rulings like "haram"/"god's will") is   │
+│     high-precision but low-volume, so it    │
+│     ties with and loses to the relational/  │
+│     emotional surface of the same sentence. │
+│     If the LLM chose any non-spirituality   │
+│     domain AND keyword detection finds       │
+│     spirituality: spirituality wins.        │
+│     The symmetric specific→specific case the│
+│     one-directional overrides above missed  │
+│     (#137). crisis/harmful never overridden.│
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
 │  3c. ISOLATION DETECTION (Phase 16.13)      │
 │     Keyword fast-path (34 phrases):         │
 │     "there is no one", "I have nobody"...   │

--- a/scenarios/domains/spirituality.yaml
+++ b/scenarios/domains/spirituality.yaml
@@ -33,6 +33,8 @@ triggers:
   - holy spirit
   - jesus told
   - allah
+  - haram
+  - halal
   - divine message
   - divine will
   - divine guidance
@@ -40,6 +42,9 @@ triggers:
   - god's presence
   - god is punishing me
   - god is testing me
+  - god's will
+  - gods will
+  - god testing me
   - god doesn't hear me
   - forsaken by god
   - why does god allow
@@ -79,6 +84,8 @@ triggers:
   - born again
   - saved
   - baptism
+  - baptised
+  - baptized
   - confirmation
   - communion
   - sacrament
@@ -157,7 +164,13 @@ triggers:
   - religious trauma
   - church hurt
   - spiritual abuse
-  - cult
+  # "cult" as a bare substring false-matches "diffiCULT", "CULTure", "ocCULT",
+  # "CULTivate" - use forms where "cult" is followed by a space + noun (culture
+  # cannot follow) so the match stays precise.
+  - cult leader
+  - cult member
+  - cult survivor
+  - cult following
   - left my church
   - leaving the church
   - deconstructing

--- a/src/models/risk_classifier.py
+++ b/src/models/risk_classifier.py
@@ -215,6 +215,9 @@ class RiskClassifier:
 
             low_confidence_triggered = False
             sanity_check_triggered = None  # Phase 17.4: set to trigger reason string when fired
+            spirituality_override = (
+                False  # Phase 21.4: set when specific->spirituality correction fires
+            )
             if llm_confidence < confidence_low and domain in sensitive_domains:
                 # Very low confidence on a sensitive domain - keyword takes over
                 keyword_domain = self._detect_domain(
@@ -301,6 +304,24 @@ class RiskClassifier:
                         keyword_domain,
                     )
                     domain = keyword_domain
+
+            # Phase 21.4: spirituality specific->specific correction (#137).
+            # The overrides above only rescue "emotional" and "logistics" labels, so
+            # a religious question the LLM reads as relational/health/money ("is it
+            # haram to leave my marriage", "my rabbi says keep faith") keeps that
+            # label and silently loses the spirituality restraint. This is the
+            # gap left by every other override being one-directional. When keyword
+            # detection - now tuned for high-signal religious terms - finds
+            # spirituality but the LLM chose a different domain, spirituality wins.
+            # Runs regardless of confidence, since the LLM here is confidently wrong.
+            if domain not in ("spirituality", "crisis", "harmful"):
+                keyword_domain = self._detect_domain(
+                    user_input, primary_domain=primary_domain, domain_streak=domain_streak
+                )
+                if keyword_domain == "spirituality":
+                    logger.info("Phase 21.4 spirituality override: llm=%s -> spirituality", domain)
+                    domain = "spirituality"
+                    spirituality_override = True
         else:
             domain = self._detect_domain(
                 user_input, primary_domain=primary_domain, domain_streak=domain_streak
@@ -382,6 +403,10 @@ class RiskClassifier:
             # Phase 17.4: Flag sanity check overrides for policy transparency.
             if sanity_check_triggered:
                 result["sanity_check_override"] = sanity_check_triggered
+
+            # Phase 21.4: Flag spirituality specific->specific corrections.
+            if spirituality_override:
+                result["spirituality_override"] = True
 
         # Check for dependency intervention
         intervention = self.loader.get_dependency_intervention(dependency_risk)
@@ -485,6 +510,17 @@ class RiskClassifier:
                     best_domain,
                 )
                 return primary_domain
+
+        # Phase 21.4: break ties toward spirituality. Religious framing (deity
+        # names, clergy, rulings like "haram" / "god's will") is high-precision but
+        # low-volume - it routinely ties 1-1 with the relational or emotional surface
+        # of the same sentence ("haram to leave my marriage", "my rabbi... my mother
+        # died"). Plain max() then loses spirituality on dict order, dropping the
+        # "don't confirm religious rulings" restraint. When spirituality is among the
+        # most-matched domains, it wins.
+        max_count = max(domain_matches.values())
+        if domain_matches.get("spirituality") == max_count:
+            return "spirituality"
 
         # Return the domain with the most trigger matches
         return max(domain_matches, key=domain_matches.get)

--- a/tests/test_spirituality_routing.py
+++ b/tests/test_spirituality_routing.py
@@ -1,0 +1,124 @@
+"""
+Phase 21.4 - spirituality domain-routing corrections (#137).
+
+Religious framing (deity names, clergy, rulings like "haram" / "god's will") is
+high-precision but low-volume, so it routinely ties with - and loses to - the
+relational or emotional surface of the same sentence. Every other override in the
+pipeline is one-directional (emotional->specific, logistics->emotional), so once
+the LLM reaches a relational label the spirituality restraint is silently dropped.
+
+These tests are deterministic: the keyword pieces use keyword-only detection, and
+the LLM override is exercised with a mocked classifier, so they run in CI.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from models.risk_classifier import RiskClassifier  # noqa: E402
+
+
+@pytest.fixture
+def rc():
+    return RiskClassifier(use_llm=False)
+
+
+class TestKeywordDetection:
+    def test_haram_beats_relational_surface(self, rc):
+        # "haram" (added) + "allah" outweigh "marriage".
+        assert (
+            rc._detect_domain(
+                "Is it haram to walk away from my marriage? I fear displeasing Allah."
+            )
+            == "spirituality"
+        )
+
+    def test_clergy_plus_grief_ties_break_to_spirituality(self, rc):
+        # "my rabbi" (spirituality) ties 1-1-1 with "my mother" and "i'm angry";
+        # the Phase 21.4 tie-break resolves to spirituality.
+        assert (
+            rc._detect_domain(
+                "My rabbi says to keep faith, but since my mother died I'm angry at God"
+            )
+            == "spirituality"
+        )
+
+    def test_gods_will_is_detected(self, rc):
+        assert (
+            rc._detect_domain("I don't know if this is God's will or if I'm making a mistake.")
+            == "spirituality"
+        )
+
+    def test_baptised_is_detected(self, rc):
+        assert (
+            rc._detect_domain("My family wants me to get baptised but I don't believe.")
+            == "spirituality"
+        )
+
+
+class TestCultSubstringFix:
+    """`cult` as a bare substring wrongly matched difficult / culture / cultivate."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "How do I have a difficult conversation with someone I care about?",
+            "Our company culture is toxic and I want to leave.",
+            "I need to cultivate better habits this year.",
+        ],
+    )
+    def test_cult_substring_no_longer_false_matches(self, rc, text):
+        assert rc._detect_domain(text) != "spirituality"
+
+    def test_genuine_cult_reference_still_detected(self, rc):
+        assert (
+            rc._detect_domain("I survived a cult leader who controlled everything")
+            == "spirituality"
+        )
+
+
+class TestSpecificToSpiritualityOverride:
+    """When the LLM picks a non-spirituality domain but keywords say spirituality."""
+
+    def _classifier_with_llm(self, llm_domain):
+        rc = RiskClassifier(use_llm=False)
+        rc._use_llm = True
+        fake = Mock()
+        fake._check_fast_path = Mock(return_value=None)
+        fake.classify = Mock(
+            return_value={
+                "domain": llm_domain,
+                "emotional_intensity": 3.0,
+                "distress_level": "none",
+                "distress_present": False,
+                "confidence": 0.95,  # high, so confidence-fallback paths are skipped
+                "classification_method": "llm",
+            }
+        )
+        rc._llm_classifier = fake
+        return rc
+
+    def test_relationships_label_corrected_to_spirituality(self):
+        rc = self._classifier_with_llm("relationships")
+        result = rc.classify(
+            "Is it haram to walk away from my marriage? I fear displeasing Allah.", []
+        )
+        assert result["domain"] == "spirituality"
+        assert result["spirituality_override"] is True
+
+    def test_non_spiritual_input_is_left_alone(self):
+        # No spirituality keyword -> override must not fire.
+        rc = self._classifier_with_llm("relationships")
+        result = rc.classify("My partner and I keep arguing about chores.", [])
+        assert result["domain"] == "relationships"
+        assert "spirituality_override" not in result
+
+    def test_crisis_label_is_never_overridden(self):
+        # Safety domains must win; the override must not pull crisis down to spirituality.
+        rc = self._classifier_with_llm("crisis")
+        result = rc.classify("I feel God has abandoned me and I want to die.", [])
+        assert result["domain"] == "crisis"


### PR DESCRIPTION
## Summary

Closes the routing gap from #137: religious questions the LLM reads as `relationships`/`emotional` (e.g. *"is it haram to leave my marriage"*, *"my rabbi says keep faith… angry at God"*) silently lost their spirituality restraint, because every override in the pipeline was one-directional.

**Investigation corrected the ROADMAP's premise.** It assumed keyword detection *finds* spirituality and an override then ignores it. Not so - keyword detection **also lost** every flagship case:
- `haram` wasn't a trigger at all (only `allah`, tying 1-1 with `marriage` and losing on dict order);
- `rabbi`+`mother died`+`angry` was a three-way 1-1-1 tie won by `relationships`;
- `god's will` / `baptised` matched **no** spirituality trigger → defaulted to `logistics`.

So a lone specific→specific override would have fired for none of them. The fix is three coordinated parts:

1. **Missing triggers** (`scenarios/domains/spirituality.yaml`): `haram`, `halal`, `god's will`, `baptised`/`baptized`.
2. **Keyword tie-break** (`_detect_domain`): when spirituality is among the most-matched domains, it wins.
3. **Symmetric override** (`classify`): when keyword detection finds spirituality but the LLM chose another domain, spirituality wins - runs regardless of LLM confidence, **never** overrides `crisis`/`harmful`. Scoped to *spirituality-wins* (the measured gravity-well victim) to bound regression risk.

### Also fixed (latent bug the override surfaced)
`cult` was a bare-substring trigger matching **diffiCULT**, **CULTure**, **CULTivate**, **ocCULT** - so *"how do I have a difficult conversation"* routed to spirituality once the override started trusting keyword signals. Replaced with collision-safe forms (`cult leader`/`member`/`survivor`/`following`).

## Testing

- **Domain eval: 81/94 → 83/94** (spirituality 10/13 → 12/13), no net regression. The 4 boundary misses (haram, rabbi, god's will, baptised) are now **deterministically** fixed (once keyword→spirituality, the override forces it regardless of the non-deterministic LLM).
- `tests/test_spirituality_routing.py` - **11 deterministic tests** (keyword-only + mocked-LLM, CI-runnable): the tie-break, each new trigger, the cult false-match fix, the override firing, non-spiritual input left alone, and crisis never overridden.
- `pytest tests/ -m "not conversation"` → **1126 passed**, coverage 66%.
- `black` + `flake8` clean.

Docs updated: `architecture.md` (new step 3b'), CHANGELOG, ROADMAP (21.4 items + corrected premise), TESTING_CHECKLIST baseline (86%→88%).

**Deferred** (#135 residual): contentless-continuation context inheritance - a separate concern from the gravity well, intentionally not bundled here.