### PR TITLE
Add --health CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to empathySync are documented here.
 
+## [Unreleased]
+
+### Added
+- `empathysync --health` CLI flag (#165, contributed by @paranoa233): runs the
+  existing startup health checks (`src/utils/health_check.py`) on demand and
+  exits 0/1, so Ollama connectivity, data-directory permissions, and the
+  optional safety guard can be verified from scripts or a shell without
+  launching the UI.
+
 ## v1.13.0 (2026-07-08) - Safety Guard Integration
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ empathysync --version                    # Print version and exit
 empathysync --list-domains               # List supported classification domains
 empathysync --list-domains --json        # Same, machine-readable JSON
 empathysync --maintenance                # Prune old data, check integrity, exit
+empathysync --health                     # Run startup health checks, exit
 empathysync --log-level DEBUG            # Override log verbosity
 
 # Docker (app + Ollama together)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ empathysync --mode cli     # Direct terminal mode
 empathysync --version      # Show version and exit
 empathysync --list-domains # List all supported classification domains
 empathysync --maintenance  # Prune old data, check integrity, and exit
+empathysync --health       # Run startup health checks and exit
 empathysync --log-level DEBUG  # Set log verbosity (DEBUG, INFO, WARNING, ERROR)
 ```
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -66,11 +66,7 @@ def list_domains(json_output=False):
     domains = loader.get_all_domains()
 
     # Sort by risk weight (descending) for better readability
-    sorted_domains = sorted(
-        domains.items(),
-        key=lambda x: x[1].get("risk_weight", 0),
-        reverse=True,
-    )
+    sorted_domains = sorted(domains.items(), key=lambda x: x[1].get("risk_weight", 0), reverse=True)
 
     if json_output:
         output = [
@@ -87,13 +83,12 @@ def list_domains(json_output=False):
         for domain_name, config in sorted_domains:
             risk_weight = config.get("risk_weight", 0)
             description = config.get("description", "")
-            # Format: domain, risk weight, and description in aligned columns.
-            prefix = f"  {domain_name:<14} risk weight: {risk_weight:<5}"
-            print(f"{prefix} - {description}")
+            # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
+            print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
 
 
 def run_maintenance():
-    """Run maintenance tasks and print a summary."""
+    """Run maintenance tasks: prune old data, validate integrity, print summary."""
     sys.path.append(str(Path(__file__).parent))
 
     from config.settings import settings
@@ -151,10 +146,7 @@ def run_maintenance():
     print(f"  Model: {settings.OLLAMA_MODEL or '(not set)'}")
     print(f"  Host: {settings.OLLAMA_HOST or '(not set)'}")
     print(f"  Storage: {'SQLite' if settings.USE_SQLITE else 'JSON'}")
-    retention_status = "  Retention: disabled"
-    if retention > 0:
-        retention_status = f"  Retention: {retention} days"
-    print(retention_status)
+    print(f"  Retention: {retention} days" if retention > 0 else "  Retention: disabled")
 
     print("\n" + "=" * 40)
     print("Maintenance complete")
@@ -185,8 +177,7 @@ def main():
     sys.path.append(str(Path(__file__).parent))
     from config.settings import settings
 
-    parser_description = "empathySync - Help that knows when to stop"
-    parser = argparse.ArgumentParser(description=parser_description)
+    parser = argparse.ArgumentParser(description="empathySync - Help that knows when to stop")
     parser.add_argument(
         "--mode",
         choices=["web", "cli"],

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,6 +6,7 @@ Usage:
     empathysync --mode web   # Same as above
     empathysync --mode cli   # Direct terminal interface (no browser needed)
     empathysync --maintenance  # Run maintenance tasks and exit
+    empathysync --health     # Run startup health checks and exit
     empathysync --version    # Print version and exit
 """
 
@@ -65,7 +66,11 @@ def list_domains(json_output=False):
     domains = loader.get_all_domains()
 
     # Sort by risk weight (descending) for better readability
-    sorted_domains = sorted(domains.items(), key=lambda x: x[1].get("risk_weight", 0), reverse=True)
+    sorted_domains = sorted(
+        domains.items(),
+        key=lambda x: x[1].get("risk_weight", 0),
+        reverse=True,
+    )
 
     if json_output:
         output = [
@@ -82,12 +87,13 @@ def list_domains(json_output=False):
         for domain_name, config in sorted_domains:
             risk_weight = config.get("risk_weight", 0)
             description = config.get("description", "")
-            # Format: domain (padded to 14 chars) risk weight (padded to 14 chars) - description
-            print(f"  {domain_name:<14} risk weight: {risk_weight:<5} - {description}")
+            # Format: domain, risk weight, and description in aligned columns.
+            prefix = f"  {domain_name:<14} risk weight: {risk_weight:<5}"
+            print(f"{prefix} - {description}")
 
 
 def run_maintenance():
-    """Run maintenance tasks: prune old data, validate integrity, print summary."""
+    """Run maintenance tasks and print a summary."""
     sys.path.append(str(Path(__file__).parent))
 
     from config.settings import settings
@@ -145,10 +151,33 @@ def run_maintenance():
     print(f"  Model: {settings.OLLAMA_MODEL or '(not set)'}")
     print(f"  Host: {settings.OLLAMA_HOST or '(not set)'}")
     print(f"  Storage: {'SQLite' if settings.USE_SQLITE else 'JSON'}")
-    print(f"  Retention: {retention} days" if retention > 0 else "  Retention: disabled")
+    retention_status = "  Retention: disabled"
+    if retention > 0:
+        retention_status = f"  Retention: {retention} days"
+    print(retention_status)
 
     print("\n" + "=" * 40)
     print("Maintenance complete")
+
+
+def run_health():
+    """Run startup health checks and return an exit code."""
+    sys.path.append(str(Path(__file__).parent))
+
+    from utils.health_check import has_critical_failures, run_health_checks
+
+    checks = run_health_checks()
+    for check in checks:
+        if check.ok:
+            marker = "[ok]"
+        elif check.critical:
+            marker = "[FAIL]"
+        else:
+            marker = "[warn]"
+
+        print(f"{marker:<6} {check.name:<18} {check.message}")
+
+    return 1 if has_critical_failures(checks) else 0
 
 
 def main():
@@ -156,7 +185,8 @@ def main():
     sys.path.append(str(Path(__file__).parent))
     from config.settings import settings
 
-    parser = argparse.ArgumentParser(description="empathySync - Help that knows when to stop")
+    parser_description = "empathySync - Help that knows when to stop"
+    parser = argparse.ArgumentParser(description=parser_description)
     parser.add_argument(
         "--mode",
         choices=["web", "cli"],
@@ -180,6 +210,11 @@ def main():
         help="Run maintenance tasks (prune data, check integrity) and exit",
     )
     parser.add_argument(
+        "--health",
+        action="store_true",
+        help="Run startup health checks and exit",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"{settings.APP_NAME} v{settings.APP_VERSION}",
@@ -201,6 +236,8 @@ def main():
         list_domains(json_output=args.json)
     elif args.maintenance:
         run_maintenance()
+    elif args.health:
+        sys.exit(run_health())
     elif args.mode == "cli":
         run_cli()
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,7 +44,10 @@ class TestCLIArguments:
         original = root.level
         try:
             with patch("src.cli.run_streamlit"):
-                with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
+                with patch(
+                    "sys.argv",
+                    ["empathysync", "--log-level", "DEBUG"],
+                ):
                     from src.cli import main
 
                     main()
@@ -58,7 +61,10 @@ class TestCLIArguments:
         original = root.level
         try:
             with patch("src.cli.run_streamlit"):
-                with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
+                with patch(
+                    "sys.argv",
+                    ["empathysync", "--log-level", "WARNING"],
+                ):
                     from src.cli import main
 
                     main()
@@ -81,7 +87,7 @@ class TestCLIArguments:
             root.setLevel(logging.WARNING)
 
     def test_log_level_invalid_choice_exits_nonzero(self):
-        """An unrecognised --log-level value causes argparse to exit non-zero."""
+        """An invalid --log-level value exits non-zero."""
         import pytest
 
         with patch("sys.argv", ["empathysync", "--log-level", "VERBOSE"]):
@@ -91,10 +97,77 @@ class TestCLIArguments:
                 main()
         assert exc_info.value.code != 0
 
+    def test_health_flag_runs_checks_and_exits_zero(self, capsys):
+        """--health runs startup checks and exits cleanly."""
+        import pytest
+        from utils.health_check import HealthStatus
+
+        checks = [
+            HealthStatus(name="Ollama Server", ok=True, message="Connected"),
+            HealthStatus(
+                name="Safety Guard",
+                ok=False,
+                message="Disabled",
+                critical=False,
+            ),
+        ]
+
+        with patch(
+            "utils.health_check.run_health_checks",
+            return_value=checks,
+        ) as mock_run:
+            with patch("sys.argv", ["empathysync", "--health"]):
+                from src.cli import main
+
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once()
+
+        output = capsys.readouterr().out
+        assert "[ok]" in output
+        assert "Ollama Server" in output
+        assert "Connected" in output
+        assert "[warn]" in output
+        assert "Safety Guard" in output
+        assert "Disabled" in output
+
+    def test_health_flag_exits_one_for_critical_failures(self, capsys):
+        """Critical health-check failures produce exit code 1."""
+        import pytest
+        from utils.health_check import HealthStatus
+
+        checks = [
+            HealthStatus(
+                name="Data Directory",
+                ok=False,
+                message="No write permission",
+                critical=True,
+            )
+        ]
+
+        with patch(
+            "utils.health_check.run_health_checks",
+            return_value=checks,
+        ):
+            with patch("sys.argv", ["empathysync", "--health"]):
+                from src.cli import main
+
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+
+        output = capsys.readouterr().out
+        assert "[FAIL]" in output
+        assert "Data Directory" in output
+        assert "No write permission" in output
+
 
 class TestListDomains:
     def test_list_domains_prints_all_domains(self, capsys):
-        """Test that list_domains prints all 8 domains with their risk weights."""
+        """list_domains prints all 8 domains with their risk weights."""
         from src.cli import list_domains
 
         list_domains()
@@ -172,8 +245,16 @@ class TestListDomains:
         data = json.loads(output)
 
         domain_names = [item["domain"] for item in data]
-        for expected in ["crisis", "harmful", "health", "money", "emotional",
-                         "relationships", "spirituality", "logistics"]:
+        for expected in [
+            "crisis",
+            "harmful",
+            "health",
+            "money",
+            "emotional",
+            "relationships",
+            "spirituality",
+            "logistics",
+        ]:
             assert expected in domain_names
 
     def test_list_domains_plain_text_unchanged_when_no_json_flag(self, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,10 +44,7 @@ class TestCLIArguments:
         original = root.level
         try:
             with patch("src.cli.run_streamlit"):
-                with patch(
-                    "sys.argv",
-                    ["empathysync", "--log-level", "DEBUG"],
-                ):
+                with patch("sys.argv", ["empathysync", "--log-level", "DEBUG"]):
                     from src.cli import main
 
                     main()
@@ -61,10 +58,7 @@ class TestCLIArguments:
         original = root.level
         try:
             with patch("src.cli.run_streamlit"):
-                with patch(
-                    "sys.argv",
-                    ["empathysync", "--log-level", "WARNING"],
-                ):
+                with patch("sys.argv", ["empathysync", "--log-level", "WARNING"]):
                     from src.cli import main
 
                     main()
@@ -87,7 +81,7 @@ class TestCLIArguments:
             root.setLevel(logging.WARNING)
 
     def test_log_level_invalid_choice_exits_nonzero(self):
-        """An invalid --log-level value exits non-zero."""
+        """An unrecognised --log-level value causes argparse to exit non-zero."""
         import pytest
 
         with patch("sys.argv", ["empathysync", "--log-level", "VERBOSE"]):
@@ -167,7 +161,7 @@ class TestCLIArguments:
 
 class TestListDomains:
     def test_list_domains_prints_all_domains(self, capsys):
-        """list_domains prints all 8 domains with their risk weights."""
+        """Test that list_domains prints all 8 domains with their risk weights."""
         from src.cli import list_domains
 
         list_domains()


### PR DESCRIPTION
## Summary
- add `empathysync --health` to run startup health checks without launching the app
- print one concise line per check with `[ok]`, `[warn]`, or `[FAIL]`
- exit with status 1 only when `has_critical_failures()` reports a critical failure
- add CLI tests for success, non-critical warnings, and critical failures

Closes #165

## Testing
- `python -m pytest tests/test_cli.py -q --no-cov`
- `python -m black --check src/cli.py tests/test_cli.py`
- `python -m flake8 src/cli.py tests/test_cli.py`

## Notes
- `python -m pytest tests/test_cli.py -q` currently fails the repository-wide coverage threshold when only this test file is run; the 17 tests themselves pass.
- `python -m black --check src` and `python -m flake8 src` still report pre-existing repository-wide issues outside this focused change.
