### PR TITLE
fix: install.sh recovers from partial venv and suggests the configured model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- `install.sh` no longer gets stuck after a failed first run: a venv creation
+  failure (typically Ubuntu without `python3-venv`) used to leave a partial
+  `venv/` directory that made every retry fail with `venv/bin/pip: No such
+  file or directory`. The installer now checks for a working `venv/bin/pip`
+  instead of the directory and recreates incomplete venvs. Found by the
+  clean-machine install test (Ubuntu 24.04 container).
+- `install.sh` Ollama-missing hint now suggests pulling the configured
+  `OLLAMA_MODEL` from `.env` instead of the long-stale `llama2`.
+
 ### Changed
 - ROADMAP.md planned phases (22, 19, 23.2-23.4) now carry an execution
   contract and per-sub-phase "Done when / Verify / Pitfalls" acceptance

--- a/install.sh
+++ b/install.sh
@@ -46,9 +46,13 @@ fi
 # 2. Create virtual environment
 echo ""
 echo "Setting up virtual environment..."
-if [ -d "venv" ]; then
+if [ -x "venv/bin/pip" ]; then
     ok "Virtual environment already exists"
 else
+    if [ -d "venv" ]; then
+        warn "Incomplete virtual environment found (a previous run failed) - recreating"
+        rm -rf venv
+    fi
     python3 -m venv venv
     ok "Virtual environment created"
 fi
@@ -78,19 +82,20 @@ ok "Data directory ready"
 # 6. Check Ollama
 echo ""
 echo "Checking Ollama..."
+
+# Determine which model is configured (.env was created in step 4)
+CONFIGURED_MODEL=""
+if [ -f ".env" ]; then
+    CONFIGURED_MODEL=$(grep -E '^OLLAMA_MODEL=' .env | cut -d= -f2- | tr -d '"' | tr -d "'" | xargs)
+fi
+CONFIGURED_MODEL="${CONFIGURED_MODEL:-llama3.2}"
+
 if command -v ollama &> /dev/null; then
     ok "Ollama installed"
 
     # Check if Ollama is running
     if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
         ok "Ollama server running"
-
-        # Determine which model is configured
-        CONFIGURED_MODEL=""
-        if [ -f ".env" ]; then
-            CONFIGURED_MODEL=$(grep -E '^OLLAMA_MODEL=' .env | cut -d= -f2- | tr -d '"' | tr -d "'" | xargs)
-        fi
-        CONFIGURED_MODEL="${CONFIGURED_MODEL:-llama3.2}"
 
         # Check for models
         MODEL_COUNT=$(curl -s http://localhost:11434/api/tags | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('models',[])))" 2>/dev/null || echo "0")
@@ -133,7 +138,7 @@ else
     warn "Ollama not installed"
     echo "  Install: curl -fsSL https://ollama.com/install.sh | sh"
     echo "  Then: ollama serve"
-    echo "  Then: ollama pull llama2"
+    echo "  Then: ollama pull $CONFIGURED_MODEL"
 fi
 
 # Done


### PR DESCRIPTION
## Summary

Closes out the deferred clean-machine install test (v1.11 open item). Ran `install.sh` in fresh Ubuntu 24.04 containers and fixed the two defects it surfaced:

1. **Retry poisoning**: a failed `python3 -m venv` (the common case: Ubuntu ships `python3` without `python3-venv`) left a partial `venv/` behind. Every retry then reported "Virtual environment already exists" and crashed at `venv/bin/pip: No such file or directory`. The existence check now tests for a working `venv/bin/pip` rather than the directory, and recreates incomplete venvs with a warning.
2. **Stale model hint**: the Ollama-not-installed message suggested `ollama pull llama2`. The `OLLAMA_MODEL` lookup is hoisted above the Ollama check (`.env` is guaranteed to exist by then - step 4 creates it), so the hint now names the configured model.

## Testing

Clean Ubuntu 24.04 container matrix:
- **Happy path** (python3 + python3-venv + python3-pip, no Ollama): exit 0; venv, `.env`, `data/` created; Streamlit imports; Ollama warning path as documented.
- **Bare machine** (no Python): fails fast with the correct apt command, exit 1.
- **No python3-venv, then retry**: first run fails with Ubuntu's own guidance; after `apt install python3-venv`, the retry detects the incomplete venv, recreates it, and completes with exit 0 (previously exit 127).
- **Boot smoke test**: `streamlit run src/app.py --server.headless true` answers `/_stcore/health` within 1s on the clean machine.
- Full structural suite: 1128 passed, 23 deselected. Domain eval untouched (no classifier changes).