### PR TITLE
fix: pin safety guard off in tests regardless of local .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to empathySync are documented here.
   clean-machine install test (Ubuntu 24.04 container).
 - `install.sh` Ollama-missing hint now suggests pulling the configured
   `OLLAMA_MODEL` from `.env` instead of the long-stale `llama2`.
+- Test suite is now hermetic against the local `.env` safety-guard opt-in:
+  `config/settings.py` loads `.env` at import, so a developer with
+  `OLLAMA_SAFETY_MODEL` set would run every unit test with the guard active,
+  breaking 4 streaming tests that mock the guard-less pipeline. A
+  session-scoped conftest fixture now pins the guard off by default;
+  guard-specific tests keep opting in explicitly.
 
 ### Changed
 - ROADMAP.md planned phases (22, 19, 23.2-23.4) now carry an execution

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,23 @@ def deterministic_ollama():
     settings.OLLAMA_SEED = 42
     yield
     settings.OLLAMA_SEED = original
+
+
+@pytest.fixture(autouse=True, scope="session")
+def safety_guard_off_by_default():
+    """Pin the safety guard off for the whole suite, regardless of local .env.
+
+    config/settings.py calls load_dotenv() at import, so a developer who has
+    opted into OLLAMA_SAFETY_MODEL in their .env would otherwise run every
+    unit test with the guard active - breaking tests that mock the guard-less
+    pipeline (e.g. TestStreaming in test_wellness_guide.py). Tests that
+    exercise the guard opt in explicitly via SafetyClassifier(model=...) or
+    monkeypatch.setattr on the settings singleton, both of which override
+    this pin.
+    """
+    from config.settings import settings
+
+    original = settings.OLLAMA_SAFETY_MODEL
+    settings.OLLAMA_SAFETY_MODEL = ""
+    yield
+    settings.OLLAMA_SAFETY_MODEL = original


### PR DESCRIPTION
## Summary

Makes the test suite hermetic against the developer's local `.env`: with `OLLAMA_SAFETY_MODEL` set (the documented Phase 21 guard opt-in), 4 `TestStreaming` tests in `test_wellness_guide.py` failed because the guard ran inside tests that mock the guard-less pipeline. A session-scoped conftest fixture now pins the guard off for the suite; guard tests keep opting in explicitly.

## Changes

- `tests/conftest.py`: new `safety_guard_off_by_default` session-scoped autouse fixture pinning `settings.OLLAMA_SAFETY_MODEL = ""` (same idiom as the existing `deterministic_ollama` seed pin)
- `CHANGELOG.md`: entry under Unreleased > Fixed

## Details

`config/settings.py` calls `load_dotenv()` at import time, so tests inherit whatever is in the local `.env`. With the guard enabled, `SafetyClassifier.classify()` runs against the mocked `utils.http_client` client, raises (`'Mock' object is not iterable`), and the stream falls back to a generic reflection instead of the crisis/harmful/practical path under test. A contributor with the guard enabled would conclude they broke the pipeline.

Guard behaviour tests are unaffected: they opt in via `SafetyClassifier(model=...)` or `monkeypatch.setattr` on the settings singleton, both of which override the pin.

## Related Issues

None (found while setting up a new dev machine whose `.env` enables the guard).

## Testing

- [x] `pytest tests/` passes (structural: 1128 passed)
- [x] Full structural suite passes **with** `OLLAMA_SAFETY_MODEL=llama-guard3:1b` exported - previously 4 failed
- [x] `tests/test_safety_classifier.py` + `tests/test_health_check_safety_guard.py` pass **without** the var (45 passed) - the pin doesn't mask guard tests
- [x] `black --check src/` passes (pre-commit)
- [x] Domain eval not run: test-infrastructure only, no classifier/scenario change
