### PR TITLE
docs: add 2026-07-13 Spark spot-check to model benchmark

### DIFF
--- a/docs/model-benchmark.md
+++ b/docs/model-benchmark.md
@@ -4,6 +4,30 @@ Performance of Ollama models on empathySync's stress test corpus (20 scenarios) 
 
 _Last run: 2026-04-26 15:20 UTC_
 
+> **2026-07-13 spot-check (Spark/GB10 hardware, full 94-example domain set; distress
+> recall not re-measured this run).**
+>
+> | Model | Min VRAM | Domain Acc | Avg Latency |
+> |-------|:--------:|:----------:|:-----------:|
+> | `qwen2.5:7b-instruct` | 8 GB | 90% (85/94) | 1.87s |
+> | `phi4:latest` | 12 GB | 88% (83/94) | 9.61s |
+> | `mistral:7b-instruct` | 8 GB | 88% (83/94) | 1.94s |
+> | `gemma3:12b` | 12 GB | 87% (82/94) | 3.49s |
+> | `qwen2.5:14b-instruct-q4_K_M` | 12 GB | 85% (80/94) | 3.20s |
+> | `gemma3:4b` | 4 GB | 84% (79/94) | 2.00s |
+> | `llama3.1:8b` | 8 GB | 84% (79/94) | 2.27s |
+> | `gemma2:9b` | 10 GB | 82% (77/94) | 2.60s |
+> | `llama3.2:latest` | 4 GB | 78% (73/94) | 1.07s |
+> | `qwen2.5:3b-instruct` | 4 GB | 78% (73/94) | 1.11s |
+> | `llama3.2:1b` | CPU / Any | 54% (51/94) | 0.88s |
+>
+> `qwen2.5:7b-instruct` is the new best-in-class, overtaking `mistral:7b-instruct`
+> at the same VRAM tier and similar latency. Anomaly: `phi4:latest` latency is ~3x
+> slower than similarly-sized `gemma3:12b`/`qwen2.5:14b` despite comparable accuracy -
+> unconfirmed cause, worth a rerun before trusting that number. Distress recall and
+> FP rate columns from the table below were not re-measured; treat this as
+> domain-accuracy-only until a follow-up covers distress.
+
 ---
 
 ## Classifier


### PR DESCRIPTION
## Summary

Adds a 2026-07-13 spot-check to `docs/model-benchmark.md`, run on GB10/Spark hardware across the full 94-example domain set (11 models), plus a CHANGELOG entry. Docs-only; no code touched.

## Changes

- New dated block above the existing table: Min VRAM / Domain Acc / Avg Latency for 11 models. `qwen2.5:7b-instruct` is the new best-in-class classifier at 90% (85/94), overtaking `mistral:7b-instruct` at the same 8 GB tier.
- Flagged a `phi4:latest` latency anomaly (~3x slower than similarly-sized models) as unconfirmed, worth a rerun.
- CHANGELOG `[Unreleased]` entry under Documentation.

## Related Issues

None.

## Scope / caveats

- Domain-accuracy only. Distress recall and FP-rate were NOT re-measured this run; the block says so. The README engine scenario-pass table and the recommended classifier are deliberately left unchanged (different metric; a classifier swap needs distress-recall verification not done here).

## Testing

- [x] `pytest tests/` passes (CI green; docs-only, no code changed)
- [x] `black --check src/` passes (CI green)
- [ ] Manually tested (if applicable) - N/A, docs-only
- [ ] New tests added for new functionality (if applicable) - N/A
