### PR TITLE
docs: changelog entry for the 2026-07-13 benchmark spot-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+### Documentation
+- `docs/model-benchmark.md`: added a 2026-07-13 spot-check (Spark/GB10 hardware,
+  full 94-example domain set, 11 models). `qwen2.5:7b-instruct` is the new
+  best-in-class classifier at 90%, overtaking `mistral:7b-instruct` at the same
+  8 GB tier. Domain-accuracy only; distress recall and FP rate not re-measured,
+  so the engine scenario-pass table and recommended classifier are unchanged.
+
 ### Fixed
 - `install.sh` no longer gets stuck after a failed first run: a venv creation
   failure (typically Ubuntu without `python3-venv`) used to leave a partial


### PR DESCRIPTION
## Summary

Follow-up to #172. The benchmark doc landed there, but the matching CHANGELOG entry was left off main (only the first commit of #172 got squashed). This adds the `[Unreleased]` entry the merge checklist requires. Docs-only; no code touched.

## Changes

- `CHANGELOG.md`: `[Unreleased]` Documentation entry recording the 2026-07-13 domain-classifier spot-check. Notes it is domain-accuracy only, so the README engine scenario-pass table and recommended classifier are deliberately unchanged.

## Related Issues

Follow-up to #172.

## Testing

- [x] `pytest tests/` passes (docs-only, no code changed)
- [x] `black --check src/` passes
- [ ] Manually tested (if applicable) - N/A, docs-only
- [ ] New tests added for new functionality (if applicable) - N/A
