### PR TITLE
docs: sync cli.py usage docstring with actual flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to empathySync are documented here.
 ## [Unreleased]
 
 ### Documentation
+- `src/cli.py`: module-docstring `Usage:` block now lists the `--list-domains`,
+  `--list-domains --json`, and `--log-level` flags it had been omitting, so the
+  in-file usage summary matches the actual argument parser.
 - `docs/model-benchmark.md`: added a 2026-07-13 spot-check (Spark/GB10 hardware,
   full 94-example domain set, 11 models). `qwen2.5:7b-instruct` is the new
   best-in-class classifier at 90%, overtaking `mistral:7b-instruct` at the same

--- a/src/cli.py
+++ b/src/cli.py
@@ -5,9 +5,12 @@ Usage:
     empathysync              # Launches Streamlit web interface (default)
     empathysync --mode web   # Same as above
     empathysync --mode cli   # Direct terminal interface (no browser needed)
+    empathysync --list-domains         # Print supported domains and risk weights, then exit
+    empathysync --list-domains --json  # Same, as machine-readable JSON
     empathysync --maintenance  # Run maintenance tasks and exit
     empathysync --health     # Run startup health checks and exit
     empathysync --version    # Print version and exit
+    empathysync --log-level DEBUG  # Override log verbosity
 """
 
 import sys


### PR DESCRIPTION
## Summary

The `src/cli.py` module docstring's `Usage:` block was missing three flags that the argument parser actually supports: `--list-domains`, `--list-domains --json`, and `--log-level`. This syncs the in-file usage summary with the real parser. Docstring-only; no behaviour change.

## Changes

- `src/cli.py`: add the three missing flags to the module-docstring `Usage:` block.
- `CHANGELOG.md`: `[Unreleased]` Documentation entry.

## Related Issues

None.

## Testing

- [x] `pytest tests/test_cli.py -q` - 17 passed
- [x] `black --check src/cli.py` passes
- [x] `flake8 src/cli.py` passes under the project config (`--max-line-length=100`)
- [ ] Manually tested (if applicable) - N/A, docstring-only
- [ ] Screenshots (if UI change) - N/A
