### PR TITLE
release: v1.14.0 - Adversarial Restraint Eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to empathySync are documented here.
 
 ## [Unreleased]
 
+## v1.14.0 (2026-08-01) - Adversarial Restraint Eval
+
 ### Documentation
 - `src/cli.py`: module-docstring `Usage:` block now lists the `--list-domains`,
   `--list-domains --json`, and `--log-level` flags it had been omitting, so the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 *Most chatbots want you to keep talking.*
 *This one wants you to leave and go live your life.*
 
-[![v1.13.0](https://img.shields.io/badge/release-v1.13.0-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.13.0)
+[![v1.14.0](https://img.shields.io/badge/release-v1.14.0-orange.svg)](https://github.com/Olawoyin007/empathySync/releases/tag/v1.14.0)
 [![CI](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml/badge.svg)](https://github.com/Olawoyin007/empathySync/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Local-First](https://img.shields.io/badge/Privacy-Local--First-blue.svg)](#)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,16 +390,19 @@ Each agent evolution phase must maintain these cross-cutting guarantees:
 
 ---
 
-## Current Status (2026-07-10)
+## Current Status (2026-08-01)
 
-**Released**: v1.13.0 (2026-07-08, "Safety Guard Integration"). Phases 1-17, 21,
-and 23.1 complete.
+**Released**: v1.14.0 (2026-08-01, "Adversarial Restraint Eval"): self
+red-teaming Inspect eval, classifier-side domain scorer, `--health` CLI flag,
+plus install/test-hermeticity fixes. No pipeline or corpus changes. Prior:
+v1.13.0 (2026-07-08, "Safety Guard Integration"). Phases 1-17, 21, and 23.1
+complete.
 
 **Safety pipeline depth**: 7 independent layers - post-crisis check, cooldown, keyword
 detection, LLM classification, confidence calibration (17.2), distress routing (17.1),
 sanity check (17.4). Each layer is independent; failure of one does not bypass others.
 
-**Test suite**: 1128 structural tests + 23 conversation-marked tests (20 quality
+**Test suite**: 1150 structural tests + 23 conversation-marked tests (20 quality
 scenarios + 3 safety-guard integration). Distress corpus CI gate: 0% FN rate. Keyword
 FP rate on benign content: 7%. Domain eval baseline: 83/94 (88%) on mistral:7b-instruct.
 
@@ -434,11 +437,12 @@ domain-routing corrections) shipped in v1.13.0.
 
 ## Version Targets
 
-Shipped versions v0.2 through v1.13.0 are recorded in
+Shipped versions v0.2 through v1.14.0 are recorded in
 [CHANGELOG.md](CHANGELOG.md) and [docs/roadmap-history.md](docs/roadmap-history.md).
 
 **v1.12** (Phase 23.1 + hygiene): negative memory invariant, dead-config removal, pipeline correctness fixes
 **v1.13** (Phase 21): purpose-trained safety classifier + domain routing corrections
+**v1.14** (tooling): adversarial restraint eval (Inspect) + classifier-side domain scorer + `--health` CLI flag
 **v2.0** (Phase 22): persistent agent daemon with self-restriction
 **v2.1** (Phase 19): multilingual support
 **v2.2** (Phase 23.2-23.4): cross-session decay, "What empathySync Remembers", measurement framework

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "empathysync"
-version = "1.13.0"
+version = "1.14.0"
 description = "A local-first AI assistant that provides full help for practical tasks while applying restraint on sensitive topics"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -17,7 +17,7 @@ class Settings:
 
     # Application
     APP_NAME: str = "empathySync"
-    APP_VERSION: str = "1.13.0"
+    APP_VERSION: str = "1.14.0"
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary

Release **v1.14.0 - "Adversarial Restraint Eval"**. Version-bump-only PR; all feature work already landed in prior merged PRs (#166, #169, #170, #172-#178).

Bumps the version across all four version-bearing files (verified by `scripts/check_version.py`):
- `pyproject.toml`, `src/config/settings.py`, `README.md` badge, `CHANGELOG.md` header (`[Unreleased]` -> `v1.14.0 (2026-08-01)`).
- `ROADMAP.md`: status block refreshed (test count 1128 -> 1150), v1.14 added to Version Targets.

**No pipeline, prompt, or corpus changes in this release.** What shipped since v1.13.0:
- Adversarial restraint eval (Inspect) under `evals/` - self red-teaming, findings-only (#176).
- Classifier-side `--mode domain` scorer for the restraint eval (#178).
- `empathysync --health` CLI flag (#166).
- Fixes: `install.sh` venv recovery + model hint (#169), test hermeticity against local `.env` safety-guard opt-in (#170).
- Docs: cli.py usage docstring sync (#174), 2026-07-13 benchmark spot-check (#172, #173).

## Testing

- `scripts/check_version.py` -> all four version references consistent at 1.14.0.
- `pytest tests/ -q -m "not conversation"` -> **1150 passed**, 23 deselected.
- `pre-commit` (black + flake8) -> passed on commit.
- `python tests/classification/run_domain_eval.py` -> **83/94 (88%)** on mistral:7b-instruct, matching the documented baseline exactly (no classifier/corpus change this release; misses are the known boundary cases).

Follows the Release procedure in `MERGE_CHECKLIST.md`. Tag + GitHub release to follow after merge.
