### PR TITLE
feat: enforce co-design editable/locked boundary (#182)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # MANIFESTO.md is protected — changes require owner review.
 # The CI also blocks PRs that modify this file.
 MANIFESTO.md @Olawoyin007
+
+# The crisis domain is the safety floor (co_design_boundary: locked).
+# It is never clinician-editable via the co-design form; changes require owner review.
+scenarios/domains/crisis.yaml @Olawoyin007

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -350,6 +350,28 @@ and silently leave the other half English-only.
 
 ---
 
+## Phase 24: Clinician Co-Design Tooling (Guided Form → Reviewed PR) 🔜 PLANNED
+
+Lets non-coding clinicians shape safety-response **language** through a guided
+form that opens a reviewed pull request, never a private local edit - so the
+public review gate stays intact and no one gets a private safety dial.
+Delivers on paper section 5.3 (participatory co-design). See issue #182.
+
+The editable/locked boundary is **decided** (2026-08-11) and enforced now as
+`co_design_boundary` in `scenarios/config/system_defaults.yaml` plus a
+CODEOWNERS lock on `crisis.yaml`: therapists shape the language (triggers,
+response text, response rules); the maintainer keeps the numbers and the floor
+(risk weight, thresholds, crisis hard-stop). Still to design: the form itself
+(fields, hosting, who may open it), the reviewer UX, the add-vs-remove trigger
+guardrail, and - only if it widens past a single trusted reviewer - the
+reviewer-pool governance.
+
+**Locked-field snapshot test** (blocks non-crisis `risk_weight` drift) is
+deferred until the form exists; until then the only changes come through
+maintainer-reviewed PRs.
+
+---
+
 ## Messaging Integration (retired as a phase)
 
 The former Phase 18 (WhatsApp/Signal/Slack adapters) is retired: WhatsApp and Slack

--- a/scenarios/config/system_defaults.yaml
+++ b/scenarios/config/system_defaults.yaml
@@ -205,3 +205,22 @@ restraint_memory:
     reach_outs: [id, person_id, method, notes, outcome, created_at]
   legacy_deny_named_columns:
     self_reports: [content]         # holds the user's self-report answer; rename deferred to a future migration
+
+# ---------------------------------------------------------------------------
+# Co-design boundary (decided 2026-08-11; see issue #182 and ~/decisions).
+# ---------------------------------------------------------------------------
+# When clinicians shape safety responses through a guided form (form -> reviewed
+# PR), the form may edit ONLY the field-level keys under `form_editable`.
+# Everything under `locked` stays in the maintainer-reviewed core and never
+# flows through the form. The line: therapists shape the LANGUAGE; the
+# maintainer keeps the NUMBERS and the FLOOR. This block is the single source of
+# truth a future form/guard reads; crisis.yaml is additionally CODEOWNERS-locked.
+co_design_boundary:
+  form_editable:          # per-domain language a clinician may shape (add triggers freely; removals need review)
+    - triggers            # keyword list that flags a domain
+    - response_rules      # plain-language "how to behave when this domain is active"
+    - redirects           # pre-written response text
+  locked:                 # numbers and the floor - maintainer core only, never via the form
+    - risk_weight         # 0-10 domain severity score (all domains)
+    - thresholds          # restraint timing and turn limits (this file)
+    - crisis_domain       # the entire crisis.yaml domain: hard-stop, triggers, escalation markers


### PR DESCRIPTION
## Summary

Turns the co-design editable/locked boundary (decided 2026-08-11) from prose
into enforcement, so the "locked" fields are protected before any guided form
exists.

- **`scenarios/config/system_defaults.yaml`** - new `co_design_boundary` block:
  `form_editable` (triggers, response_rules, redirects) vs `locked` (risk_weight,
  thresholds, crisis_domain). This is the single source of truth a future form or
  guard reads. The line: therapists shape the language; the maintainer keeps the
  numbers and the floor.
- **`.github/CODEOWNERS`** - locks `scenarios/domains/crisis.yaml` (the safety
  floor) behind owner review, the same way MANIFESTO.md is protected.
- **`ROADMAP.md`** - Phase 24 stub (Clinician Co-Design Tooling), recording the
  settled boundary and the still-open design work.

Deferred by decision: the non-crisis `risk_weight` snapshot test. Before a form
exists, the only changes to those weights come through maintainer-reviewed PRs,
so the test would mostly nag during normal tuning. It lands the day the form does.

Closes nothing; tracks under #182.

## Testing

- `pytest tests/ -m "not conversation"` - 1150 passed, coverage 66%.
- YAML validated; `co_design_boundary` loads with the expected two lists.
