### PR TITLE
docs: refresh stale test counts to 1150 unit + 23 conversation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ empathysync --log-level DEBUG            # Override log verbosity
 docker compose up
 
 # Tests
-pytest tests/                            # Full suite (1126 unit + 23 conversation)
+pytest tests/                            # Full suite (1150 unit + 23 conversation)
 pytest tests/ --cov=src                  # With coverage
 pytest tests/ -m "not conversation"      # Skip Ollama-dependent tests
 python tests/classification/run_domain_eval.py          # Domain accuracy eval
@@ -111,7 +111,7 @@ tests/
     └── run_domain_eval.py          # Per-domain accuracy report
 ```
 
-Current counts: ~1126 unit tests, 23 conversation-marked tests (20 quality scenarios + 3 safety-guard integration).
+Current counts: ~1150 unit tests, 23 conversation-marked tests (20 quality scenarios + 3 safety-guard integration).
 
 Pre-existing known failure: `stress_test_001` conversation tier is
 non-deterministic (LLM output varies); the structural tier always passes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ phase without guessing:
    never weaken the test to get past it. Conversation content and
    preference/persona data are never persistable, in any encoding.
 4. Verify before declaring done: `pytest tests/ -m "not conversation"` (all
-   ~1128 must pass) plus the sub-phase's own **Verify** line. Run
+   ~1150 must pass) plus the sub-phase's own **Verify** line. Run
    `python tests/classification/run_domain_eval.py` only when classification
    code or scenario YAML changed (baseline: 83/94 on mistral:7b-instruct).
 5. When a step is ambiguous, take the smallest interpretation that satisfies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -636,7 +636,7 @@ empathySync/
 │
 ├── data/                        # Local user data (JSON/SQLite)
 ├── logs/                        # Application logs
-├── tests/                       # Pytest test suite (1126 unit + 23 conversation-marked)
+├── tests/                       # Pytest test suite (1150 unit + 23 conversation-marked)
 └── docs/                        # Documentation
 ```
 


### PR DESCRIPTION
## Summary

Three docs still cited the old test count (1126/1128). This bumps them to the current numbers.

| File | Was | Now |
|------|-----|-----|
| `CLAUDE.md` (x2) | 1126 unit | 1150 unit |
| `ROADMAP.md` | ~1128 must pass | ~1150 must pass |
| `docs/architecture.md` | 1126 unit | 1150 unit |

Docs-only, no code changes.

## Testing

```
pytest tests/ -m conversation --collect-only
23/1173 tests collected (1150 deselected)
```

1173 total = 1150 unit + 23 conversation-marked, matching the refreshed counts.
